### PR TITLE
Improve effect cancellation on dismiss

### DIFF
--- a/Sources/ComposablePresentation/Reducer+Combined.swift
+++ b/Sources/ComposablePresentation/Reducer+Combined.swift
@@ -13,14 +13,15 @@ extension Reducer {
   /// - Parameters:
   ///   - other: Another reducer.
   ///   - shouldRun: Closure used to determine if the other reducer should be run.
-  ///       It takes `Action` as a parameter.
-  ///   - cancelEffects: Closure used to determine if the effects returned by the another reducer should be cancelled.
-  ///       It takes two parameters of type `State`: the state before and after running the reducer.
+  ///       It takes `Action` as a parameter. Defaults to a closure thtat always returns `true`.
+  ///   - shouldCancelEffects: Closure used to determine if the effects returned by the another reducer should be
+  ///       cancelled. It takes two parameters of type `State`: the state before and after running the reducer.
+  ///       Defaults to a closure that always retruns `false`.
   /// - Returns: A single, combined reducer.
   public func combined(
     with other: Reducer<State, Action, Environment>,
-    run shouldRun: @escaping (Action) -> Bool,
-    cancelEffects shouldCancelEffects: @escaping (State, State) -> Bool
+    shouldRun: @escaping (Action) -> Bool = { _ in true },
+    shouldCancelEffects: @escaping (State, State) -> Bool = { _, _ in false }
   ) -> Self {
     let otherEffectsId = EffectsId()
     return Reducer { state, action, environment in

--- a/Sources/ComposablePresentation/Reducer+Combined.swift
+++ b/Sources/ComposablePresentation/Reducer+Combined.swift
@@ -5,7 +5,7 @@ extension Reducer {
   ///
   /// - Another reducer is run before the reducer on which the function is invoked.
   /// - All effects returned by the reducers are merged.
-  /// - The `cancelEffects` closure is run with a `State` reduced by both reducers.
+  /// - The `cancelEffects` closure is run with a `State` before and after reducing by both reducers.
   /// - If the closure returns `true`, all effects returned by another reducer are canceled.
   ///
   /// Based on [Reducer.presents function](https://github.com/pointfreeco/swift-composable-architecture/blob/9ec4b71e5a84f448dedb063a21673e4696ce135f/Sources/ComposableArchitecture/Reducer.swift#L549-L572) from `iso` branch of `swift-composable-architecture` repository.
@@ -13,20 +13,21 @@ extension Reducer {
   /// - Parameters:
   ///   - other: Another reducer.
   ///   - cancelEffects: Closure used to determine if the effects returned by the another reducer should be cancelled.
+  ///       It takes two parameters of type `State`: the state before and after running the reducer.
   /// - Returns: A single, combined reducer.
   public func combined(
     with other: Reducer<State, Action, Environment>,
-    cancelEffects: @escaping (State) -> Bool
+    cancelEffects: @escaping (State, State) -> Bool
   ) -> Self {
     let otherEffectsId = EffectsId()
     return Reducer { state, action, environment in
+      let oldState = state
       let otherEffects = other
         .run(&state, action, environment)
         .cancellable(id: otherEffectsId)
-
       let effects = run(&state, action, environment)
-
-      let shouldCancelOtherEffects = cancelEffects(state)
+      let newState = state
+      let shouldCancelOtherEffects = cancelEffects(oldState, newState)
 
       return .merge(
         otherEffects,

--- a/Sources/ComposablePresentation/Reducer+Combined.swift
+++ b/Sources/ComposablePresentation/Reducer+Combined.swift
@@ -29,6 +29,12 @@ extension Reducer {
       let newState = state
       let shouldCancelOtherEffects = cancelEffects(oldState, newState)
 
+      #if DEBUG
+      if shouldCancelOtherEffects {
+        combinedReducerOtherEffectsCancellationCount += 1
+      }
+      #endif
+
       return .merge(
         otherEffects,
         effects,
@@ -41,3 +47,7 @@ extension Reducer {
 private struct EffectsId: Hashable {
   let id = UUID()
 }
+
+#if DEBUG
+var combinedReducerOtherEffectsCancellationCount: Int = 0
+#endif

--- a/Sources/ComposablePresentation/Reducer+Combined.swift
+++ b/Sources/ComposablePresentation/Reducer+Combined.swift
@@ -29,12 +29,6 @@ extension Reducer {
       let newState = state
       let shouldCancelOtherEffects = cancelEffects(oldState, newState)
 
-      #if DEBUG
-      if shouldCancelOtherEffects {
-        combinedReducerOtherEffectsCancellationCount += 1
-      }
-      #endif
-
       return .merge(
         otherEffects,
         effects,
@@ -47,7 +41,3 @@ extension Reducer {
 private struct EffectsId: Hashable {
   let id = UUID()
 }
-
-#if DEBUG
-var combinedReducerOtherEffectsCancellationCount: Int = 0
-#endif

--- a/Sources/ComposablePresentation/Reducer+PresentsCasePath.swift
+++ b/Sources/ComposablePresentation/Reducer+PresentsCasePath.swift
@@ -29,7 +29,7 @@ extension Reducer {
         environment: toLocalEnvironment
       ),
       run: { action in
-        let shouldRun = true // TODO: check action
+        let shouldRun = toLocalAction.extract(from: action) != nil
         if shouldRun { onRun() }
         return shouldRun
       },

--- a/Sources/ComposablePresentation/Reducer+PresentsCasePath.swift
+++ b/Sources/ComposablePresentation/Reducer+PresentsCasePath.swift
@@ -10,6 +10,7 @@ extension Reducer {
   ///   - toLocalState: A case path that can extract/embed `LocalState` from `State`.
   ///   - toLocalAction: A case path that can extract/embed `LocalAction` from `Action`.
   ///   - toLocalEnvironment: A function that transforms `Environment` into `LocalEnvironment`.
+  ///   - onRun: A closure invoked when another reducer is run. Defaults to an empty closure.
   ///   - onCancel: A closure invoked when effects produced by another reducer are being cancelled.
   ///       Defaults to an empty closure.
   /// - Returns: A single, combined reducer.
@@ -18,6 +19,7 @@ extension Reducer {
     state toLocalState: CasePath<State, LocalState>,
     action toLocalAction: CasePath<Action, LocalAction>,
     environment toLocalEnvironment: @escaping (Environment) -> LocalEnvironment,
+    onRun: @escaping () -> Void = {},
     onCancel: @escaping () -> Void = {}
   ) -> Self {
     combined(
@@ -26,6 +28,11 @@ extension Reducer {
         action: toLocalAction,
         environment: toLocalEnvironment
       ),
+      run: { action in
+        let shouldRun = true // TODO: check action
+        if shouldRun { onRun() }
+        return shouldRun
+      },
       cancelEffects: { oldState, newState in
         let wasPresented = toLocalState.extract(from: oldState) != nil
         let isDismissed = toLocalState.extract(from: newState) == nil

--- a/Sources/ComposablePresentation/Reducer+PresentsCasePath.swift
+++ b/Sources/ComposablePresentation/Reducer+PresentsCasePath.swift
@@ -23,8 +23,8 @@ extension Reducer {
         action: toLocalAction,
         environment: toLocalEnvironment
       ),
-      cancelEffects: { state in
-        toLocalState.extract(from: state) == nil
+      cancelEffects: { _, newState in
+        toLocalState.extract(from: newState) == nil
       }
     )
   }

--- a/Sources/ComposablePresentation/Reducer+PresentsCasePath.swift
+++ b/Sources/ComposablePresentation/Reducer+PresentsCasePath.swift
@@ -28,12 +28,12 @@ extension Reducer {
         action: toLocalAction,
         environment: toLocalEnvironment
       ),
-      run: { action in
+      shouldRun: { action in
         let shouldRun = toLocalAction.extract(from: action) != nil
         if shouldRun { onRun() }
         return shouldRun
       },
-      cancelEffects: { oldState, newState in
+      shouldCancelEffects: { oldState, newState in
         let wasPresented = toLocalState.extract(from: oldState) != nil
         let isDismissed = toLocalState.extract(from: newState) == nil
         let shouldCancel = wasPresented && isDismissed

--- a/Sources/ComposablePresentation/Reducer+PresentsCasePath.swift
+++ b/Sources/ComposablePresentation/Reducer+PresentsCasePath.swift
@@ -23,8 +23,10 @@ extension Reducer {
         action: toLocalAction,
         environment: toLocalEnvironment
       ),
-      cancelEffects: { _, newState in
-        toLocalState.extract(from: newState) == nil
+      cancelEffects: { oldState, newState in
+        let wasPresented = toLocalState.extract(from: oldState) != nil
+        let isDismissed = toLocalState.extract(from: newState) == nil
+        return wasPresented && isDismissed
       }
     )
   }

--- a/Sources/ComposablePresentation/Reducer+PresentsKeyPath.swift
+++ b/Sources/ComposablePresentation/Reducer+PresentsKeyPath.swift
@@ -32,12 +32,12 @@ extension Reducer {
         action: toLocalAction,
         environment: toLocalEnvironment
       ),
-      run: { action in
+      shouldRun: { action in
         let shouldRun = toLocalAction.extract(from: action) != nil
         if shouldRun { onRun() }
         return shouldRun
       },
-      cancelEffects: { oldState, newState in
+      shouldCancelEffects: { oldState, newState in
         let wasPresented = oldState[keyPath: toLocalState] != nil
         let isDismissed = newState[keyPath: toLocalState] == nil
         let shouldCancel = wasPresented && isDismissed

--- a/Sources/ComposablePresentation/Reducer+PresentsKeyPath.swift
+++ b/Sources/ComposablePresentation/Reducer+PresentsKeyPath.swift
@@ -27,8 +27,8 @@ extension Reducer {
         action: toLocalAction,
         environment: toLocalEnvironment
       ),
-      cancelEffects: { state in
-        state[keyPath: toLocalState] == nil
+      cancelEffects: { _, newState in
+        newState[keyPath: toLocalState] == nil
       }
     )
   }

--- a/Sources/ComposablePresentation/Reducer+PresentsKeyPath.swift
+++ b/Sources/ComposablePresentation/Reducer+PresentsKeyPath.swift
@@ -27,8 +27,10 @@ extension Reducer {
         action: toLocalAction,
         environment: toLocalEnvironment
       ),
-      cancelEffects: { _, newState in
-        newState[keyPath: toLocalState] == nil
+      cancelEffects: { oldState, newState in
+        let wasPresented = oldState[keyPath: toLocalState] != nil
+        let isDismissed = newState[keyPath: toLocalState] == nil
+        return wasPresented && isDismissed
       }
     )
   }

--- a/Sources/ComposablePresentation/Reducer+PresentsKeyPath.swift
+++ b/Sources/ComposablePresentation/Reducer+PresentsKeyPath.swift
@@ -33,7 +33,7 @@ extension Reducer {
         environment: toLocalEnvironment
       ),
       run: { action in
-        let shouldRun = true // TODO: check action
+        let shouldRun = toLocalAction.extract(from: action) != nil
         if shouldRun { onRun() }
         return shouldRun
       },

--- a/Sources/ComposablePresentation/Reducer+PresentsKeyPath.swift
+++ b/Sources/ComposablePresentation/Reducer+PresentsKeyPath.swift
@@ -13,13 +13,16 @@ extension Reducer {
   ///   - toLocalState: A key path that can get/set `LocalState` inside `State`.
   ///   - toLocalAction: A case path that can extract/embed `LocalAction` from `Action`.
   ///   - toLocalEnvironment: A function that transforms `Environment` into `LocalEnvironment`.
+  ///   - onCancel: A closure invoked when effects produced by another reducer are being cancelled.
+  ///       Defaults to an empty closure.
   /// - Returns: A single, combined reducer.
   public func presents<LocalState, LocalAction, LocalEnvironment>(
     _ localReducer: Reducer<LocalState, LocalAction, LocalEnvironment>,
     breakpointOnNil: Bool = true,
     state toLocalState: WritableKeyPath<State, LocalState?>,
     action toLocalAction: CasePath<Action, LocalAction>,
-    environment toLocalEnvironment: @escaping (Environment) -> LocalEnvironment
+    environment toLocalEnvironment: @escaping (Environment) -> LocalEnvironment,
+    onCancel: @escaping () -> Void = {}
   ) -> Self {
     combined(
       with: localReducer.optional(breakpointOnNil: breakpointOnNil).pullback(
@@ -30,7 +33,9 @@ extension Reducer {
       cancelEffects: { oldState, newState in
         let wasPresented = oldState[keyPath: toLocalState] != nil
         let isDismissed = newState[keyPath: toLocalState] == nil
-        return wasPresented && isDismissed
+        let shouldCancel = wasPresented && isDismissed
+        if shouldCancel { onCancel() }
+        return shouldCancel
       }
     )
   }

--- a/Sources/ComposablePresentation/Reducer+PresentsKeyPath.swift
+++ b/Sources/ComposablePresentation/Reducer+PresentsKeyPath.swift
@@ -13,6 +13,7 @@ extension Reducer {
   ///   - toLocalState: A key path that can get/set `LocalState` inside `State`.
   ///   - toLocalAction: A case path that can extract/embed `LocalAction` from `Action`.
   ///   - toLocalEnvironment: A function that transforms `Environment` into `LocalEnvironment`.
+  ///   - onRun: A closure invoked when another reducer is run. Defaults to an empty closure.
   ///   - onCancel: A closure invoked when effects produced by another reducer are being cancelled.
   ///       Defaults to an empty closure.
   /// - Returns: A single, combined reducer.
@@ -22,6 +23,7 @@ extension Reducer {
     state toLocalState: WritableKeyPath<State, LocalState?>,
     action toLocalAction: CasePath<Action, LocalAction>,
     environment toLocalEnvironment: @escaping (Environment) -> LocalEnvironment,
+    onRun: @escaping () -> Void = {},
     onCancel: @escaping () -> Void = {}
   ) -> Self {
     combined(
@@ -30,6 +32,11 @@ extension Reducer {
         action: toLocalAction,
         environment: toLocalEnvironment
       ),
+      run: { action in
+        let shouldRun = true // TODO: check action
+        if shouldRun { onRun() }
+        return shouldRun
+      },
       cancelEffects: { oldState, newState in
         let wasPresented = oldState[keyPath: toLocalState] != nil
         let isDismissed = newState[keyPath: toLocalState] == nil

--- a/Tests/ComposablePresentationTests/ReducerCombinedTests.swift
+++ b/Tests/ComposablePresentationTests/ReducerCombinedTests.swift
@@ -43,11 +43,11 @@ final class ReducerCombinedTests: XCTestCase {
           .map { "child-effect-\($0)" }
           .eraseToEffect()
       },
-      run: { action in
+      shouldRun: { action in
         self.didCallRunOnAction.append(action)
         return self.shouldRunChildReducer
       },
-      cancelEffects: { oldState, newState in
+      shouldCancelEffects: { oldState, newState in
         self.didCallCancelEffectsOnState.append(DidCancelEffects(oldState: oldState, newState: newState))
         return self.shouldCancelChildEffect
       }

--- a/Tests/ComposablePresentationTests/ReducerPresentsCasePathTests.swift
+++ b/Tests/ComposablePresentationTests/ReducerPresentsCasePathTests.swift
@@ -44,7 +44,7 @@ final class ReducerPresentsCasePathTests: XCTestCase {
     XCTAssertEqual(didCancelFirstEffect, 0)
     XCTAssertEqual(didSubscribeToSecondEffect, 0)
     XCTAssertEqual(didCancelSecondEffect, 0)
-    XCTAssertEqual(combinedReducerOtherEffectsCancellationCount, 1)
+    XCTAssertEqual(combinedReducerOtherEffectsCancellationCount, 0)
 
     store.send(.presentSecondDetail) {
       $0 = .second(SecondDetailState())
@@ -54,7 +54,7 @@ final class ReducerPresentsCasePathTests: XCTestCase {
     XCTAssertEqual(didCancelFirstEffect, 1)
     XCTAssertEqual(didSubscribeToSecondEffect, 0)
     XCTAssertEqual(didCancelSecondEffect, 0)
-    XCTAssertEqual(combinedReducerOtherEffectsCancellationCount, 2)
+    XCTAssertEqual(combinedReducerOtherEffectsCancellationCount, 1)
 
     store.send(.second(.performEffect))
 
@@ -62,7 +62,7 @@ final class ReducerPresentsCasePathTests: XCTestCase {
     XCTAssertEqual(didCancelFirstEffect, 1)
     XCTAssertEqual(didSubscribeToSecondEffect, 1)
     XCTAssertEqual(didCancelSecondEffect, 0)
-    XCTAssertEqual(combinedReducerOtherEffectsCancellationCount, 3)
+    XCTAssertEqual(combinedReducerOtherEffectsCancellationCount, 1)
 
     store.send(.presentFirstDetail) {
       $0 = .first(FirstDetailState())
@@ -72,7 +72,7 @@ final class ReducerPresentsCasePathTests: XCTestCase {
     XCTAssertEqual(didCancelFirstEffect, 1)
     XCTAssertEqual(didSubscribeToSecondEffect, 1)
     XCTAssertEqual(didCancelSecondEffect, 1)
-    XCTAssertEqual(combinedReducerOtherEffectsCancellationCount, 4)
+    XCTAssertEqual(combinedReducerOtherEffectsCancellationCount, 2)
   }
 }
 

--- a/Tests/ComposablePresentationTests/ReducerPresentsCasePathTests.swift
+++ b/Tests/ComposablePresentationTests/ReducerPresentsCasePathTests.swift
@@ -6,10 +6,10 @@ import XCTest
 
 final class ReducerPresentsCasePathTests: XCTestCase {
   func testCancelEffectsOnDismiss() {
-    var didSubscribeToFirstEffect = false
-    var didCancelFirstEffect = false
-    var didSubscribeToSecondEffect = false
-    var didCancelSecondEffect = false
+    var didSubscribeToFirstEffect = 0
+    var didCancelFirstEffect = 0
+    var didSubscribeToSecondEffect = 0
+    var didCancelSecondEffect = 0
 
     let store = TestStore(
       initialState: MasterState.first(FirstDetailState()),
@@ -18,16 +18,16 @@ final class ReducerPresentsCasePathTests: XCTestCase {
         firstDetail: FirstDetailEnvironment(effect: {
           Empty(completeImmediately: false)
             .handleEvents(
-              receiveSubscription: { _ in didSubscribeToFirstEffect = true },
-              receiveCancel: { didCancelFirstEffect = true }
+              receiveSubscription: { _ in didSubscribeToFirstEffect += 1 },
+              receiveCancel: { didCancelFirstEffect += 1 }
             )
             .eraseToEffect()
         }),
         secondDetail: SecondDetailEnvironment(effect: {
           Empty(completeImmediately: false)
             .handleEvents(
-              receiveSubscription: { _ in didSubscribeToSecondEffect = true },
-              receiveCancel: { didCancelSecondEffect = true }
+              receiveSubscription: { _ in didSubscribeToSecondEffect += 1 },
+              receiveCancel: { didCancelSecondEffect += 1 }
             )
             .eraseToEffect()
         })
@@ -36,23 +36,36 @@ final class ReducerPresentsCasePathTests: XCTestCase {
 
     store.send(.first(.performEffect))
 
-    XCTAssertTrue(didSubscribeToFirstEffect)
+    XCTAssertEqual(didSubscribeToFirstEffect, 1)
+    XCTAssertEqual(didCancelFirstEffect, 0)
+    XCTAssertEqual(didSubscribeToSecondEffect, 0)
+    XCTAssertEqual(didCancelSecondEffect, 0)
+
 
     store.send(.presentSecondDetail) {
       $0 = .second(SecondDetailState())
     }
 
-    XCTAssertTrue(didCancelFirstEffect)
+    XCTAssertEqual(didSubscribeToFirstEffect, 1)
+    XCTAssertEqual(didCancelFirstEffect, 1)
+    XCTAssertEqual(didSubscribeToSecondEffect, 0)
+    XCTAssertEqual(didCancelSecondEffect, 0)
 
     store.send(.second(.performEffect))
 
-    XCTAssertTrue(didSubscribeToSecondEffect)
+    XCTAssertEqual(didSubscribeToFirstEffect, 1)
+    XCTAssertEqual(didCancelFirstEffect, 1)
+    XCTAssertEqual(didSubscribeToSecondEffect, 1)
+    XCTAssertEqual(didCancelSecondEffect, 0)
 
     store.send(.presentFirstDetail) {
       $0 = .first(FirstDetailState())
     }
 
-    XCTAssertTrue(didCancelSecondEffect)
+    XCTAssertEqual(didSubscribeToFirstEffect, 1)
+    XCTAssertEqual(didCancelFirstEffect, 1)
+    XCTAssertEqual(didSubscribeToSecondEffect, 1)
+    XCTAssertEqual(didCancelSecondEffect, 1)
   }
 }
 

--- a/Tests/ComposablePresentationTests/ReducerPresentsCasePathTests.swift
+++ b/Tests/ComposablePresentationTests/ReducerPresentsCasePathTests.swift
@@ -5,6 +5,10 @@ import XCTest
 @testable import ComposablePresentation
 
 final class ReducerPresentsCasePathTests: XCTestCase {
+  override func setUp() {
+    combinedReducerOtherEffectsCancellationCount = 0
+  }
+
   func testCancelEffectsOnDismiss() {
     var didSubscribeToFirstEffect = 0
     var didCancelFirstEffect = 0
@@ -40,7 +44,7 @@ final class ReducerPresentsCasePathTests: XCTestCase {
     XCTAssertEqual(didCancelFirstEffect, 0)
     XCTAssertEqual(didSubscribeToSecondEffect, 0)
     XCTAssertEqual(didCancelSecondEffect, 0)
-
+    XCTAssertEqual(combinedReducerOtherEffectsCancellationCount, 1)
 
     store.send(.presentSecondDetail) {
       $0 = .second(SecondDetailState())
@@ -50,6 +54,7 @@ final class ReducerPresentsCasePathTests: XCTestCase {
     XCTAssertEqual(didCancelFirstEffect, 1)
     XCTAssertEqual(didSubscribeToSecondEffect, 0)
     XCTAssertEqual(didCancelSecondEffect, 0)
+    XCTAssertEqual(combinedReducerOtherEffectsCancellationCount, 2)
 
     store.send(.second(.performEffect))
 
@@ -57,6 +62,7 @@ final class ReducerPresentsCasePathTests: XCTestCase {
     XCTAssertEqual(didCancelFirstEffect, 1)
     XCTAssertEqual(didSubscribeToSecondEffect, 1)
     XCTAssertEqual(didCancelSecondEffect, 0)
+    XCTAssertEqual(combinedReducerOtherEffectsCancellationCount, 3)
 
     store.send(.presentFirstDetail) {
       $0 = .first(FirstDetailState())
@@ -66,6 +72,7 @@ final class ReducerPresentsCasePathTests: XCTestCase {
     XCTAssertEqual(didCancelFirstEffect, 1)
     XCTAssertEqual(didSubscribeToSecondEffect, 1)
     XCTAssertEqual(didCancelSecondEffect, 1)
+    XCTAssertEqual(combinedReducerOtherEffectsCancellationCount, 4)
   }
 }
 

--- a/Tests/ComposablePresentationTests/ReducerPresentsCasePathTests.swift
+++ b/Tests/ComposablePresentationTests/ReducerPresentsCasePathTests.swift
@@ -57,7 +57,7 @@ final class ReducerPresentsCasePathTests: XCTestCase {
     store.send(.first(.performEffect))
 
     XCTAssertEqual(didRunFirstPresentedReducer, 1)
-    XCTAssertEqual(didRunSecondPresentedReducer, 1)
+    XCTAssertEqual(didRunSecondPresentedReducer, 0)
     XCTAssertEqual(didCancelFirstPresentedEffects, 0)
     XCTAssertEqual(didCancelSecondPresentedEffects, 0)
     XCTAssertEqual(didSubscribeToFirstEffect, 1)
@@ -69,8 +69,8 @@ final class ReducerPresentsCasePathTests: XCTestCase {
       $0 = .second(SecondDetailState())
     }
 
-    XCTAssertEqual(didRunFirstPresentedReducer, 2)
-    XCTAssertEqual(didRunSecondPresentedReducer, 2)
+    XCTAssertEqual(didRunFirstPresentedReducer, 1)
+    XCTAssertEqual(didRunSecondPresentedReducer, 0)
     XCTAssertEqual(didCancelFirstPresentedEffects, 1)
     XCTAssertEqual(didCancelSecondPresentedEffects, 0)
     XCTAssertEqual(didSubscribeToFirstEffect, 1)
@@ -80,8 +80,8 @@ final class ReducerPresentsCasePathTests: XCTestCase {
 
     store.send(.second(.performEffect))
 
-    XCTAssertEqual(didRunFirstPresentedReducer, 3)
-    XCTAssertEqual(didRunSecondPresentedReducer, 3)
+    XCTAssertEqual(didRunFirstPresentedReducer, 1)
+    XCTAssertEqual(didRunSecondPresentedReducer, 1)
     XCTAssertEqual(didCancelFirstPresentedEffects, 1)
     XCTAssertEqual(didCancelSecondPresentedEffects, 0)
     XCTAssertEqual(didSubscribeToFirstEffect, 1)
@@ -93,8 +93,8 @@ final class ReducerPresentsCasePathTests: XCTestCase {
       $0 = .first(FirstDetailState())
     }
 
-    XCTAssertEqual(didRunFirstPresentedReducer, 4)
-    XCTAssertEqual(didRunSecondPresentedReducer, 4)
+    XCTAssertEqual(didRunFirstPresentedReducer, 1)
+    XCTAssertEqual(didRunSecondPresentedReducer, 1)
     XCTAssertEqual(didCancelFirstPresentedEffects, 1)
     XCTAssertEqual(didCancelSecondPresentedEffects, 1)
     XCTAssertEqual(didSubscribeToFirstEffect, 1)

--- a/Tests/ComposablePresentationTests/ReducerPresentsCasePathTests.swift
+++ b/Tests/ComposablePresentationTests/ReducerPresentsCasePathTests.swift
@@ -6,6 +6,8 @@ import XCTest
 
 final class ReducerPresentsCasePathTests: XCTestCase {
   func testCancelEffectsOnDismiss() {
+    var didRunFirstPresentedReducer = 0
+    var didRunSecondPresentedReducer = 0
     var didCancelFirstPresentedEffects = 0
     var didCancelSecondPresentedEffects = 0
     var didSubscribeToFirstEffect = 0
@@ -21,6 +23,7 @@ final class ReducerPresentsCasePathTests: XCTestCase {
           state: /MasterState.first,
           action: /MasterAction.first,
           environment: \.firstDetail,
+          onRun: { didRunFirstPresentedReducer += 1 },
           onCancel: { didCancelFirstPresentedEffects += 1 }
         )
         .presents(
@@ -28,6 +31,7 @@ final class ReducerPresentsCasePathTests: XCTestCase {
           state: /MasterState.second,
           action: /MasterAction.second,
           environment: \.secondDetail,
+          onRun: { didRunSecondPresentedReducer += 1 },
           onCancel: { didCancelSecondPresentedEffects += 1 }
         ),
       environment: MasterEnvironment(
@@ -52,6 +56,8 @@ final class ReducerPresentsCasePathTests: XCTestCase {
 
     store.send(.first(.performEffect))
 
+    XCTAssertEqual(didRunFirstPresentedReducer, 1)
+    XCTAssertEqual(didRunSecondPresentedReducer, 1)
     XCTAssertEqual(didCancelFirstPresentedEffects, 0)
     XCTAssertEqual(didCancelSecondPresentedEffects, 0)
     XCTAssertEqual(didSubscribeToFirstEffect, 1)
@@ -63,6 +69,8 @@ final class ReducerPresentsCasePathTests: XCTestCase {
       $0 = .second(SecondDetailState())
     }
 
+    XCTAssertEqual(didRunFirstPresentedReducer, 2)
+    XCTAssertEqual(didRunSecondPresentedReducer, 2)
     XCTAssertEqual(didCancelFirstPresentedEffects, 1)
     XCTAssertEqual(didCancelSecondPresentedEffects, 0)
     XCTAssertEqual(didSubscribeToFirstEffect, 1)
@@ -72,6 +80,8 @@ final class ReducerPresentsCasePathTests: XCTestCase {
 
     store.send(.second(.performEffect))
 
+    XCTAssertEqual(didRunFirstPresentedReducer, 3)
+    XCTAssertEqual(didRunSecondPresentedReducer, 3)
     XCTAssertEqual(didCancelFirstPresentedEffects, 1)
     XCTAssertEqual(didCancelSecondPresentedEffects, 0)
     XCTAssertEqual(didSubscribeToFirstEffect, 1)
@@ -83,6 +93,8 @@ final class ReducerPresentsCasePathTests: XCTestCase {
       $0 = .first(FirstDetailState())
     }
 
+    XCTAssertEqual(didRunFirstPresentedReducer, 4)
+    XCTAssertEqual(didRunSecondPresentedReducer, 4)
     XCTAssertEqual(didCancelFirstPresentedEffects, 1)
     XCTAssertEqual(didCancelSecondPresentedEffects, 1)
     XCTAssertEqual(didSubscribeToFirstEffect, 1)

--- a/Tests/ComposablePresentationTests/ReducerPresentsKeyPathTests.swift
+++ b/Tests/ComposablePresentationTests/ReducerPresentsKeyPathTests.swift
@@ -5,8 +5,8 @@ import XCTest
 
 final class ReducerPresentsKeyPathTests: XCTestCase {
   func testCancelEffectsOnDismiss() {
-    var didSubscribeToEffect = false
-    var didCancelEffect = false
+    var didSubscribeToEffect = 0
+    var didCancelEffect = 0
 
     let store = TestStore(
       initialState: MasterState(),
@@ -15,8 +15,8 @@ final class ReducerPresentsKeyPathTests: XCTestCase {
         detail: DetailEnvironment(effect: {
           Empty(completeImmediately: false)
             .handleEvents(
-              receiveSubscription: { _ in didSubscribeToEffect = true },
-              receiveCancel: { didCancelEffect = true }
+              receiveSubscription: { _ in didSubscribeToEffect += 1 },
+              receiveCancel: { didCancelEffect += 1 }
             )
             .eraseToEffect()
         })
@@ -27,15 +27,25 @@ final class ReducerPresentsKeyPathTests: XCTestCase {
       $0.detail = DetailState()
     }
 
+    XCTAssertEqual(didSubscribeToEffect, 0)
+    XCTAssertEqual(didCancelEffect, 0)
+
     store.send(.detail(.performEffect))
 
-    XCTAssertTrue(didSubscribeToEffect)
+    XCTAssertEqual(didSubscribeToEffect, 1)
+    XCTAssertEqual(didCancelEffect, 0)
 
     store.send(.dismissDetail) {
       $0.detail = nil
     }
 
-    XCTAssertTrue(didCancelEffect)
+    XCTAssertEqual(didSubscribeToEffect, 1)
+    XCTAssertEqual(didCancelEffect, 1)
+
+    store.send(.dismissDetail)
+
+    XCTAssertEqual(didSubscribeToEffect, 1)
+    XCTAssertEqual(didCancelEffect, 1)
   }
 }
 

--- a/Tests/ComposablePresentationTests/ReducerPresentsKeyPathTests.swift
+++ b/Tests/ComposablePresentationTests/ReducerPresentsKeyPathTests.swift
@@ -37,14 +37,14 @@ final class ReducerPresentsKeyPathTests: XCTestCase {
       $0.detail = DetailState()
     }
 
-    XCTAssertEqual(didRunPresentedReducer, 1)
+    XCTAssertEqual(didRunPresentedReducer, 0)
     XCTAssertEqual(didCancelPresentedEffects, 0)
     XCTAssertEqual(didSubscribeToEffect, 0)
     XCTAssertEqual(didCancelEffect, 0)
 
     store.send(.detail(.performEffect))
 
-    XCTAssertEqual(didRunPresentedReducer, 2)
+    XCTAssertEqual(didRunPresentedReducer, 1)
     XCTAssertEqual(didCancelPresentedEffects, 0)
     XCTAssertEqual(didSubscribeToEffect, 1)
     XCTAssertEqual(didCancelEffect, 0)
@@ -53,14 +53,14 @@ final class ReducerPresentsKeyPathTests: XCTestCase {
       $0.detail = nil
     }
 
-    XCTAssertEqual(didRunPresentedReducer, 3)
+    XCTAssertEqual(didRunPresentedReducer, 1)
     XCTAssertEqual(didCancelPresentedEffects, 1)
     XCTAssertEqual(didSubscribeToEffect, 1)
     XCTAssertEqual(didCancelEffect, 1)
 
     store.send(.dismissDetail)
 
-    XCTAssertEqual(didRunPresentedReducer, 4)
+    XCTAssertEqual(didRunPresentedReducer, 1)
     XCTAssertEqual(didCancelPresentedEffects, 1)
     XCTAssertEqual(didSubscribeToEffect, 1)
     XCTAssertEqual(didCancelEffect, 1)

--- a/Tests/ComposablePresentationTests/ReducerPresentsKeyPathTests.swift
+++ b/Tests/ComposablePresentationTests/ReducerPresentsKeyPathTests.swift
@@ -4,6 +4,10 @@ import XCTest
 @testable import ComposablePresentation
 
 final class ReducerPresentsKeyPathTests: XCTestCase {
+  override func setUp() {
+    combinedReducerOtherEffectsCancellationCount = 0
+  }
+
   func testCancelEffectsOnDismiss() {
     var didSubscribeToEffect = 0
     var didCancelEffect = 0
@@ -29,11 +33,13 @@ final class ReducerPresentsKeyPathTests: XCTestCase {
 
     XCTAssertEqual(didSubscribeToEffect, 0)
     XCTAssertEqual(didCancelEffect, 0)
+    XCTAssertEqual(combinedReducerOtherEffectsCancellationCount, 0)
 
     store.send(.detail(.performEffect))
 
     XCTAssertEqual(didSubscribeToEffect, 1)
     XCTAssertEqual(didCancelEffect, 0)
+    XCTAssertEqual(combinedReducerOtherEffectsCancellationCount, 0)
 
     store.send(.dismissDetail) {
       $0.detail = nil
@@ -41,11 +47,13 @@ final class ReducerPresentsKeyPathTests: XCTestCase {
 
     XCTAssertEqual(didSubscribeToEffect, 1)
     XCTAssertEqual(didCancelEffect, 1)
+    XCTAssertEqual(combinedReducerOtherEffectsCancellationCount, 1)
 
     store.send(.dismissDetail)
 
     XCTAssertEqual(didSubscribeToEffect, 1)
     XCTAssertEqual(didCancelEffect, 1)
+    XCTAssertEqual(combinedReducerOtherEffectsCancellationCount, 2)
   }
 }
 

--- a/Tests/ComposablePresentationTests/ReducerPresentsKeyPathTests.swift
+++ b/Tests/ComposablePresentationTests/ReducerPresentsKeyPathTests.swift
@@ -53,7 +53,7 @@ final class ReducerPresentsKeyPathTests: XCTestCase {
 
     XCTAssertEqual(didSubscribeToEffect, 1)
     XCTAssertEqual(didCancelEffect, 1)
-    XCTAssertEqual(combinedReducerOtherEffectsCancellationCount, 2)
+    XCTAssertEqual(combinedReducerOtherEffectsCancellationCount, 1)
   }
 }
 

--- a/Tests/ComposablePresentationTests/ReducerPresentsKeyPathTests.swift
+++ b/Tests/ComposablePresentationTests/ReducerPresentsKeyPathTests.swift
@@ -5,6 +5,7 @@ import XCTest
 
 final class ReducerPresentsKeyPathTests: XCTestCase {
   func testCancelEffectsOnDismiss() {
+    var didRunPresentedReducer = 0
     var didCancelPresentedEffects = 0
     var didSubscribeToEffect = 0
     var didCancelEffect = 0
@@ -17,6 +18,7 @@ final class ReducerPresentsKeyPathTests: XCTestCase {
           state: \.detail,
           action: /MasterAction.detail,
           environment: \.detail,
+          onRun: { didRunPresentedReducer += 1 },
           onCancel: { didCancelPresentedEffects += 1 }
         ),
       environment: MasterEnvironment(
@@ -35,12 +37,14 @@ final class ReducerPresentsKeyPathTests: XCTestCase {
       $0.detail = DetailState()
     }
 
+    XCTAssertEqual(didRunPresentedReducer, 1)
     XCTAssertEqual(didCancelPresentedEffects, 0)
     XCTAssertEqual(didSubscribeToEffect, 0)
     XCTAssertEqual(didCancelEffect, 0)
 
     store.send(.detail(.performEffect))
 
+    XCTAssertEqual(didRunPresentedReducer, 2)
     XCTAssertEqual(didCancelPresentedEffects, 0)
     XCTAssertEqual(didSubscribeToEffect, 1)
     XCTAssertEqual(didCancelEffect, 0)
@@ -49,12 +53,14 @@ final class ReducerPresentsKeyPathTests: XCTestCase {
       $0.detail = nil
     }
 
+    XCTAssertEqual(didRunPresentedReducer, 3)
     XCTAssertEqual(didCancelPresentedEffects, 1)
     XCTAssertEqual(didSubscribeToEffect, 1)
     XCTAssertEqual(didCancelEffect, 1)
 
     store.send(.dismissDetail)
 
+    XCTAssertEqual(didRunPresentedReducer, 4)
     XCTAssertEqual(didCancelPresentedEffects, 1)
     XCTAssertEqual(didSubscribeToEffect, 1)
     XCTAssertEqual(didCancelEffect, 1)


### PR DESCRIPTION
## Summary

This PR improves the performance by canceling effects produced by the presented reducer only when the presented state becomes `nil`. Previously the `.cancel` effect was returned from the reducer every time when any action was received and presented state was `nil`.

In addition, when using `Reducer.pesents` extension, the presented reducer is only run for actions that it can handle. This change reduces the number produced `.cancelable(id:)` effects, potentially improving performance.

## What was done

- [x] Cancel effects when the presented state becomes `nil`.
- [x] Add tests that measure the number of effect cancellations.
- [x] Run presented reducer only for actions it can handle.
- [x] Add tests that measure the number of presented reducer runs. 
 
## Review notes

This PR introduces some changes proposed in #4 . While it's just a small update, it's should positively affect the performance of reducers. Other changes mentioned in #4 are not covered in this PR but will be addressed in the future.
