### PR TITLE
Add initial macOS support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,7 @@ let package = Package(
   name: "swift-composable-presentation",
   platforms: [
     .iOS(.v14),
+    .macOS(.v10_15),
   ],
   products: [
     .library(

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Swift Composable Presentation
 
 ![Swift v5.4](https://img.shields.io/badge/swift-v5.4-orange.svg)
-![platforms iOS](https://img.shields.io/badge/platforms-iOS-blue.svg)
+![platforms iOS macOS](https://img.shields.io/badge/platforms-iOS_macOS-blue.svg)
 
 ## 📝 Description
 

--- a/Sources/ComposablePresentation/FullScreenCoverWithStore.swift
+++ b/Sources/ComposablePresentation/FullScreenCoverWithStore.swift
@@ -1,6 +1,8 @@
 import ComposableArchitecture
 import SwiftUI
 
+#if os(iOS)
+
 extension View {
   /// Adds full screen cover using `Store` with an optional `State`
   ///
@@ -41,3 +43,5 @@ extension View {
     )
   }
 }
+
+#endif


### PR DESCRIPTION
## Summary

This PR adds initial support for macOS. The library package can now be added as a dependency to apps and packages that target the macOS platform.

## What was done

- [x] Add macOS 10.15 to package platforms.

## Review notes

The library was not fully tested under macOS.
