### PR TITLE
Presenting for each

### DIFF
--- a/Example/Example.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
+++ b/Example/Example.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1250"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -27,8 +27,12 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:../Tests.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/Sources/ComposablePresentation/Reducer+PresentingForEach.swift
+++ b/Sources/ComposablePresentation/Reducer+PresentingForEach.swift
@@ -1,0 +1,61 @@
+import ComposableArchitecture
+
+extension Reducer {
+  public func presenting<LocalState, LocalAction, LocalEnvironment>(
+    forEach localReducer: Reducer<LocalState, LocalAction, LocalEnvironment>,
+    breakpointOnNil: Bool = true,
+    state toLocalState: WritableKeyPath<State, IdentifiedArrayOf<LocalState>>,
+    action toLocalAction: CasePath<Action, (LocalState.ID, LocalAction)>,
+    environment toLocalEnvironment: @escaping (Environment) -> LocalEnvironment,
+    onRun: @escaping (LocalState.ID) -> Void = { _ in },
+    onCancel: @escaping (LocalState.ID) -> Void = { _ in }
+  ) -> Self {
+    let presentationId = UUID()
+    return Reducer { state, action, environment in
+      let oldIds = state[keyPath: toLocalState].ids
+      let localEffects: Effect<Action, Never>
+
+      if let (id, _) = toLocalAction.extract(from: action) {
+        onRun(id)
+        localEffects = localReducer
+          .forEach(
+            state: toLocalState,
+            action: toLocalAction,
+            environment: toLocalEnvironment,
+            breakpointOnNil: breakpointOnNil
+          )
+          .run(&state, action, environment)
+          .cancellable(id: CancellationId(
+            presentationId: presentationId,
+            elementId: id
+          ))
+      } else {
+        localEffects = .none
+      }
+
+      let effects = run(&state, action, environment)
+      var cancellationEffects: [Effect<Action, Never>] = []
+      let newIds = state[keyPath: toLocalState].ids
+      let removedIds = oldIds.subtracting(newIds)
+
+      removedIds.forEach { id in
+        onCancel(id)
+        cancellationEffects.append(.cancel(id: CancellationId(
+          presentationId: presentationId,
+          elementId: id
+        )))
+      }
+
+      return .merge(
+        localEffects,
+        effects,
+        .merge(cancellationEffects)
+      )
+    }
+  }
+}
+
+private struct CancellationId: Hashable {
+  var presentationId: UUID
+  var elementId: AnyHashable
+}

--- a/Sources/ComposablePresentation/Reducer+PresentingForEach.swift
+++ b/Sources/ComposablePresentation/Reducer+PresentingForEach.swift
@@ -1,6 +1,23 @@
 import ComposableArchitecture
 
 extension Reducer {
+  /// Combines the reducer with another reducer that works on elements of `IdentifiedArray`.
+  ///
+  /// - All effects returned by another reducer will be canceled when `LocalState` becomes `nil`.
+  ///
+  /// - Parameters:
+  ///   - localReducer: A reducer that works on `LocalState`, `LocalAction`, `LocalEnvironment`.
+  ///   - breakpointOnNil: If `true`, raises `SIGTRAP` signal when an action is sent to the reducer
+  ///       but state is `nil`. This is generally considered a logic error, as a child reducer cannot
+  ///       process a child action for unavailable child state (defaults to `true`).
+  ///   - toLocalState: A key path from `State` to `IdentifiedArrayOf<LocalState>`.
+  ///   - toLocalAction: A case path that can extract/embed `LocalAction` from `Action`.
+  ///   - toLocalEnvironment: A function that transforms `Environment` into `LocalEnvironment`.
+  ///   - onRun: A closure invoked when another reducer is run. `LocalState.ID` is passed as an argument.
+  ///       Defaults to an empty closure.
+  ///   - onCancel: A closure invoked when effects produced by another reducer are being cancelled.
+  ///       `LocalState.ID` is passed as an argument. Defaults to an empty closure.
+  /// - Returns: A single, combined reducer.
   public func presenting<LocalState, LocalAction, LocalEnvironment>(
     forEach localReducer: Reducer<LocalState, LocalAction, LocalEnvironment>,
     breakpointOnNil: Bool = true,

--- a/Tests.xctestplan
+++ b/Tests.xctestplan
@@ -15,7 +15,7 @@
     {
       "parallelizable" : true,
       "target" : {
-        "containerPath" : "container:",
+        "containerPath" : "container:..",
         "identifier" : "ComposablePresentationTests",
         "name" : "ComposablePresentationTests"
       }

--- a/Tests/ComposablePresentationTests/ReducerPresentingForEachTests.swift
+++ b/Tests/ComposablePresentationTests/ReducerPresentingForEachTests.swift
@@ -1,0 +1,150 @@
+import Combine
+import ComposableArchitecture
+import XCTest
+@testable import ComposablePresentation
+
+final class ReducerPresentingForEachTests: XCTestCase {
+  func testCancelEffectsOnDismiss() {
+    var didRunPresentedReducer: [DetailState.ID] = []
+    var didCancelPresentedEffects: [DetailState.ID] = []
+    var didSubscribeToEffect: [DetailState.ID] = []
+    var didCancelEffect: [DetailState.ID] = []
+
+    let store = TestStore(
+      initialState: MasterState(details: []),
+      reducer: masterReducer
+        .presenting(
+          forEach: detailReducer,
+          state: \.details,
+          action: /MasterAction.detail(id:action:),
+          environment: \.detail,
+          onRun: { didRunPresentedReducer.append($0) },
+          onCancel: { didCancelPresentedEffects.append($0) }
+        ),
+      environment: MasterEnvironment(
+        detail: DetailEnvironment(
+          effect: { id in
+            Empty(completeImmediately: false)
+              .handleEvents(
+                receiveSubscription: { _ in didSubscribeToEffect.append(id) },
+                receiveCancel: { didCancelEffect.append(id) }
+              )
+              .eraseToEffect()
+          }
+        )
+      )
+    )
+
+    store.send(.presentDetail(id: 1)) {
+      $0.details.append(DetailState(id: 1))
+    }
+
+    XCTAssertEqual(didRunPresentedReducer, [])
+    XCTAssertEqual(didCancelPresentedEffects, [])
+    XCTAssertEqual(didSubscribeToEffect, [])
+    XCTAssertEqual(didCancelEffect, [])
+
+    store.send(.detail(id: 1, action: .performEffect))
+
+    XCTAssertEqual(didRunPresentedReducer, [1])
+    XCTAssertEqual(didCancelPresentedEffects, [])
+    XCTAssertEqual(didSubscribeToEffect, [1])
+    XCTAssertEqual(didCancelEffect, [])
+
+    store.send(.presentDetail(id: 2)) {
+      $0.details.append(DetailState(id: 2))
+    }
+
+    XCTAssertEqual(didRunPresentedReducer, [1])
+    XCTAssertEqual(didCancelPresentedEffects, [])
+    XCTAssertEqual(didSubscribeToEffect, [1])
+    XCTAssertEqual(didCancelEffect, [])
+
+    store.send(.detail(id: 2, action: .performEffect))
+
+    XCTAssertEqual(didRunPresentedReducer, [1, 2])
+    XCTAssertEqual(didCancelPresentedEffects, [])
+    XCTAssertEqual(didSubscribeToEffect, [1, 2])
+    XCTAssertEqual(didCancelEffect, [])
+
+    store.send(.dismissDetail(id: 1)) {
+      $0.details.remove(id: 1)
+    }
+
+    XCTAssertEqual(didRunPresentedReducer, [1, 2])
+    XCTAssertEqual(didCancelPresentedEffects, [1])
+    XCTAssertEqual(didSubscribeToEffect, [1, 2])
+    XCTAssertEqual(didCancelEffect, [1])
+
+    store.send(.dismissDetail(id: 2)) {
+      $0.details.remove(id: 2)
+    }
+
+    XCTAssertEqual(didRunPresentedReducer, [1, 2])
+    XCTAssertEqual(didCancelPresentedEffects, [1, 2])
+    XCTAssertEqual(didSubscribeToEffect, [1, 2])
+    XCTAssertEqual(didCancelEffect, [1, 2])
+  }
+}
+
+// MARK: - Master component
+
+private struct MasterState: Equatable {
+  var details: IdentifiedArrayOf<DetailState>
+}
+
+private enum MasterAction: Equatable {
+  case presentDetail(id: Int)
+  case dismissDetail(id: Int)
+  case detail(id: Int, action: DetailAction)
+}
+
+private struct MasterEnvironment {
+  var detail: DetailEnvironment
+}
+
+private typealias MasterReducer = Reducer<MasterState, MasterAction, MasterEnvironment>
+
+private let masterReducer = MasterReducer { state, action, env in
+  switch action {
+  case let .presentDetail(id):
+    state.details.append(DetailState(id: id))
+    return .none
+
+  case let .dismissDetail(id):
+    _ = state.details.remove(id: id)
+    return .none
+
+  case .detail(_, _):
+    return .none
+  }
+}
+
+// MARK: - Detail component
+
+private struct DetailState: Equatable, Identifiable {
+  var id: Int
+}
+
+private enum DetailAction: Equatable {
+  case performEffect
+  case didPerformEffect
+}
+
+private struct DetailEnvironment {
+  var effect: (DetailState.ID) -> Effect<Void, Never>
+}
+
+private typealias DetailReducer = Reducer<DetailState, DetailAction, DetailEnvironment>
+
+private let detailReducer = DetailReducer { state, action, env in
+  switch action {
+  case .performEffect:
+    return env.effect(state.id)
+      .map { _ in DetailAction.didPerformEffect }
+      .eraseToEffect()
+
+  case .didPerformEffect:
+    return .none
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds a new extension to `Reducer` which creates a reducer that presents elements contained in `IdentifiedArray`.

## What was done

- [x] Add `Reducer.presenting` extension that works with `ForEachStore`.
- [x] Update example app with `ForEachStore` usage example.
