### PR TITLE
Add presentation actions to `Reducer.presenting`

### DIFF
--- a/Tests/ComposablePresentationTests/ReducerPresentingCasePathTests.swift
+++ b/Tests/ComposablePresentationTests/ReducerPresentingCasePathTests.swift
@@ -5,48 +5,146 @@ import XCTest
 @testable import ComposablePresentation
 
 final class ReducerPresentingCasePathTests: XCTestCase {
-  func testCancelEffectsOnDismiss() {
-    var didRunFirstPresentedReducer = 0
-    var didRunSecondPresentedReducer = 0
-    var didCancelFirstPresentedEffects = 0
-    var didCancelSecondPresentedEffects = 0
-    var didSubscribeToFirstEffect = 0
+  func testPresenting() {
+    var didPresentFirst = 0
+    var didRunFirstReducer = 0
+    var didFireFirstEffect = 0
+    var didDismissFirst = 0
     var didCancelFirstEffect = 0
-    var didSubscribeToSecondEffect = 0
+
+    var didPresentSecond = 0
+    var didRunSecondReducer = 0
+    var didFireSecondEffect = 0
+    var didDismissSecond = 0
     var didCancelSecondEffect = 0
 
+    enum MasterState: Equatable {
+      case first(FirstState)
+      case second(SecondState)
+    }
+
+    enum MasterAction: Equatable {
+      case presentFirst
+      case presentSecond
+      case first(FirstAction)
+      case second(SecondAction)
+    }
+
+    struct MasterEnvironment {
+      var first: FirstEnvironment
+      var second: SecondEnvironment
+    }
+
+    let masterReducer = Reducer<MasterState, MasterAction, MasterEnvironment>
+    { state, action, env in
+      switch action {
+      case .presentFirst:
+        state = .first(FirstState())
+        return .none
+
+      case .presentSecond:
+        state = .second(SecondState())
+        return .none
+
+      case .first(_), .second(_):
+        return .none
+      }
+    }
+
+    struct FirstState: Equatable {}
+
+    enum FirstAction: Equatable {
+      case performEffect
+      case didPerformEffect
+    }
+
+    struct FirstEnvironment {
+      var effect: () -> Effect<Void, Never>
+    }
+
+    let firstReducer = Reducer<FirstState, FirstAction, FirstEnvironment>
+    { state, action, env in
+      didRunFirstReducer += 1
+      switch action {
+      case .performEffect:
+        return env.effect()
+          .map { _ in FirstAction.didPerformEffect }
+          .eraseToEffect()
+
+      case .didPerformEffect:
+        return .none
+      }
+    }
+
+    struct SecondState: Equatable {}
+
+    enum SecondAction: Equatable {
+      case performEffect
+      case didPerformEffect
+    }
+
+    struct SecondEnvironment {
+      var effect: () -> Effect<Void, Never>
+    }
+
+    let secondReducer = Reducer<SecondState, SecondAction, SecondEnvironment>
+    { state, action, env in
+      didRunSecondReducer += 1
+      switch action {
+      case .performEffect:
+        return env.effect()
+          .map { _ in SecondAction.didPerformEffect }
+          .eraseToEffect()
+
+      case .didPerformEffect:
+        return .none
+      }
+    }
+
     let store = TestStore(
-      initialState: MasterState.first(FirstDetailState()),
+      initialState: MasterState.first(FirstState()),
       reducer: masterReducer
         .presenting(
-          firstDetailReducer,
+          firstReducer,
           state: /MasterState.first,
           action: /MasterAction.first,
-          environment: \.firstDetail,
-          onRun: { didRunFirstPresentedReducer += 1 },
-          onCancel: { didCancelFirstPresentedEffects += 1 }
+          environment: \.first,
+          onPresent: .init { _, _ in
+            didPresentFirst += 1
+            return .none
+          },
+          onDismiss: .init { _, _ in
+            didDismissFirst += 1
+            return .none
+          }
         )
         .presenting(
-          secondDetailReducer,
+          secondReducer,
           state: /MasterState.second,
           action: /MasterAction.second,
-          environment: \.secondDetail,
-          onRun: { didRunSecondPresentedReducer += 1 },
-          onCancel: { didCancelSecondPresentedEffects += 1 }
+          environment: \.second,
+          onPresent: .init { _, _ in
+            didPresentSecond += 1
+            return .none
+          },
+          onDismiss: .init { _, _ in
+            didDismissSecond += 1
+            return .none
+          }
         ),
       environment: MasterEnvironment(
-        firstDetail: FirstDetailEnvironment(effect: {
+        first: FirstEnvironment(effect: {
           Empty(completeImmediately: false)
             .handleEvents(
-              receiveSubscription: { _ in didSubscribeToFirstEffect += 1 },
+              receiveSubscription: { _ in didFireFirstEffect += 1 },
               receiveCancel: { didCancelFirstEffect += 1 }
             )
             .eraseToEffect()
         }),
-        secondDetail: SecondDetailEnvironment(effect: {
+        second: SecondEnvironment(effect: {
           Empty(completeImmediately: false)
             .handleEvents(
-              receiveSubscription: { _ in didSubscribeToSecondEffect += 1 },
+              receiveSubscription: { _ in didFireSecondEffect += 1 },
               receiveCancel: { didCancelSecondEffect += 1 }
             )
             .eraseToEffect()
@@ -56,137 +154,62 @@ final class ReducerPresentingCasePathTests: XCTestCase {
 
     store.send(.first(.performEffect))
 
-    XCTAssertEqual(didRunFirstPresentedReducer, 1)
-    XCTAssertEqual(didRunSecondPresentedReducer, 0)
-    XCTAssertEqual(didCancelFirstPresentedEffects, 0)
-    XCTAssertEqual(didCancelSecondPresentedEffects, 0)
-    XCTAssertEqual(didSubscribeToFirstEffect, 1)
+    XCTAssertEqual(didPresentFirst, 0)
+    XCTAssertEqual(didRunFirstReducer, 1)
+    XCTAssertEqual(didFireFirstEffect, 1)
+    XCTAssertEqual(didDismissFirst, 0)
     XCTAssertEqual(didCancelFirstEffect, 0)
-    XCTAssertEqual(didSubscribeToSecondEffect, 0)
+
+    XCTAssertEqual(didPresentSecond, 0)
+    XCTAssertEqual(didRunSecondReducer, 0)
+    XCTAssertEqual(didFireSecondEffect, 0)
+    XCTAssertEqual(didDismissSecond, 0)
     XCTAssertEqual(didCancelSecondEffect, 0)
 
-    store.send(.presentSecondDetail) {
-      $0 = .second(SecondDetailState())
+    store.send(.presentSecond) {
+      $0 = .second(SecondState())
     }
 
-    XCTAssertEqual(didRunFirstPresentedReducer, 1)
-    XCTAssertEqual(didRunSecondPresentedReducer, 0)
-    XCTAssertEqual(didCancelFirstPresentedEffects, 1)
-    XCTAssertEqual(didCancelSecondPresentedEffects, 0)
-    XCTAssertEqual(didSubscribeToFirstEffect, 1)
+    XCTAssertEqual(didPresentFirst, 0)
+    XCTAssertEqual(didRunFirstReducer, 1)
+    XCTAssertEqual(didFireFirstEffect, 1)
+    XCTAssertEqual(didDismissFirst, 1)
     XCTAssertEqual(didCancelFirstEffect, 1)
-    XCTAssertEqual(didSubscribeToSecondEffect, 0)
+
+    XCTAssertEqual(didPresentSecond, 1)
+    XCTAssertEqual(didRunSecondReducer, 0)
+    XCTAssertEqual(didFireSecondEffect, 0)
+    XCTAssertEqual(didDismissSecond, 0)
     XCTAssertEqual(didCancelSecondEffect, 0)
 
     store.send(.second(.performEffect))
 
-    XCTAssertEqual(didRunFirstPresentedReducer, 1)
-    XCTAssertEqual(didRunSecondPresentedReducer, 1)
-    XCTAssertEqual(didCancelFirstPresentedEffects, 1)
-    XCTAssertEqual(didCancelSecondPresentedEffects, 0)
-    XCTAssertEqual(didSubscribeToFirstEffect, 1)
+    XCTAssertEqual(didPresentFirst, 0)
+    XCTAssertEqual(didRunFirstReducer, 1)
+    XCTAssertEqual(didFireFirstEffect, 1)
+    XCTAssertEqual(didDismissFirst, 1)
     XCTAssertEqual(didCancelFirstEffect, 1)
-    XCTAssertEqual(didSubscribeToSecondEffect, 1)
+
+    XCTAssertEqual(didPresentSecond, 1)
+    XCTAssertEqual(didRunSecondReducer, 1)
+    XCTAssertEqual(didFireSecondEffect, 1)
+    XCTAssertEqual(didDismissSecond, 0)
     XCTAssertEqual(didCancelSecondEffect, 0)
 
-    store.send(.presentFirstDetail) {
-      $0 = .first(FirstDetailState())
+    store.send(.presentFirst) {
+      $0 = .first(FirstState())
     }
 
-    XCTAssertEqual(didRunFirstPresentedReducer, 1)
-    XCTAssertEqual(didRunSecondPresentedReducer, 1)
-    XCTAssertEqual(didCancelFirstPresentedEffects, 1)
-    XCTAssertEqual(didCancelSecondPresentedEffects, 1)
-    XCTAssertEqual(didSubscribeToFirstEffect, 1)
+    XCTAssertEqual(didPresentFirst, 1)
+    XCTAssertEqual(didRunFirstReducer, 1)
+    XCTAssertEqual(didFireFirstEffect, 1)
+    XCTAssertEqual(didDismissFirst, 1)
     XCTAssertEqual(didCancelFirstEffect, 1)
-    XCTAssertEqual(didSubscribeToSecondEffect, 1)
+
+    XCTAssertEqual(didPresentSecond, 1)
+    XCTAssertEqual(didRunSecondReducer, 1)
+    XCTAssertEqual(didFireSecondEffect, 1)
+    XCTAssertEqual(didDismissSecond, 1)
     XCTAssertEqual(didCancelSecondEffect, 1)
-  }
-}
-
-// MARK: - Master component
-
-private enum MasterState: Equatable {
-  case first(FirstDetailState)
-  case second(SecondDetailState)
-}
-
-private enum MasterAction: Equatable {
-  case presentFirstDetail
-  case presentSecondDetail
-  case first(FirstDetailAction)
-  case second(SecondDetailAction)
-}
-
-private struct MasterEnvironment {
-  var firstDetail: FirstDetailEnvironment
-  var secondDetail: SecondDetailEnvironment
-}
-
-private let masterReducer = Reducer<MasterState, MasterAction, MasterEnvironment>
-{ state, action, env in
-  switch action {
-  case .presentFirstDetail:
-    state = .first(FirstDetailState())
-    return .none
-
-  case .presentSecondDetail:
-    state = .second(SecondDetailState())
-    return .none
-
-  case .first(_), .second(_):
-    return .none
-  }
-}
-
-// MARK: - FirstDetail component
-
-private struct FirstDetailState: Equatable {}
-
-private enum FirstDetailAction: Equatable {
-  case performEffect
-  case didPerformEffect
-}
-
-private struct FirstDetailEnvironment {
-  var effect: () -> Effect<Void, Never>
-}
-
-private let firstDetailReducer = Reducer<FirstDetailState, FirstDetailAction, FirstDetailEnvironment>
-{ state, action, env in
-  switch action {
-  case .performEffect:
-    return env.effect()
-      .map { _ in FirstDetailAction.didPerformEffect }
-      .eraseToEffect()
-
-  case .didPerformEffect:
-    return .none
-  }
-}
-
-// MARK: - SecondDetail component
-
-private struct SecondDetailState: Equatable {}
-
-private enum SecondDetailAction: Equatable {
-  case performEffect
-  case didPerformEffect
-}
-
-private struct SecondDetailEnvironment {
-  var effect: () -> Effect<Void, Never>
-}
-
-private let secondDetailReducer = Reducer<SecondDetailState, SecondDetailAction, SecondDetailEnvironment>
-{ state, action, env in
-  switch action {
-  case .performEffect:
-    return env.effect()
-      .map { _ in SecondDetailAction.didPerformEffect }
-      .eraseToEffect()
-
-  case .didPerformEffect:
-    return .none
   }
 }

--- a/Tests/ComposablePresentationTests/ReducerPresentingKeyPathTests.swift
+++ b/Tests/ComposablePresentationTests/ReducerPresentingKeyPathTests.swift
@@ -4,11 +4,67 @@ import XCTest
 @testable import ComposablePresentation
 
 final class ReducerPresentingKeyPathTests: XCTestCase {
-  func testCancelEffectsOnDismiss() {
-    var didRunPresentedReducer = 0
-    var didCancelPresentedEffects = 0
-    var didSubscribeToEffect = 0
-    var didCancelEffect = 0
+  func testPresenting() {
+    var didPresentDetail = 0
+    var didRunDetailReducer = 0
+    var didFireDetailEffect = 0
+    var didDismissDetail = 0
+    var didCancelDetailEffect = 0
+
+    struct MasterState: Equatable {
+      var detail: DetailState?
+    }
+
+    enum MasterAction: Equatable {
+      case presentDetail
+      case dismissDetail
+      case detail(DetailAction)
+    }
+
+    struct MasterEnvironment {
+      var detail: DetailEnvironment
+    }
+
+    let masterReducer = Reducer<MasterState, MasterAction, MasterEnvironment>
+    { state, action, env in
+      switch action {
+      case .presentDetail:
+        state.detail = DetailState()
+        return .none
+
+      case .dismissDetail:
+        state.detail = nil
+        return .none
+
+      case .detail:
+        return .none
+      }
+    }
+
+    struct DetailState: Equatable {}
+
+    enum DetailAction: Equatable {
+      case performEffect
+      case didPerformEffect
+    }
+
+    struct DetailEnvironment {
+      var effect: () -> Effect<Void, Never>
+    }
+
+    let detailReducer = Reducer<DetailState, DetailAction, DetailEnvironment>
+    { state, action, env in
+      didRunDetailReducer += 1
+      switch action {
+      case .performEffect:
+        return env.effect()
+          .map { _ in DetailAction.didPerformEffect }
+          .eraseToEffect()
+
+      case .didPerformEffect:
+        return .none
+      }
+    }
 
     let store = TestStore(
       initialState: MasterState(),
@@ -18,15 +74,21 @@ final class ReducerPresentingKeyPathTests: XCTestCase {
           state: \.detail,
           action: /MasterAction.detail,
           environment: \.detail,
-          onRun: { didRunPresentedReducer += 1 },
-          onCancel: { didCancelPresentedEffects += 1 }
+          onPresent: .init { _, _ in
+            didPresentDetail += 1
+            return .none
+          },
+          onDismiss: .init { _, _ in
+            didDismissDetail += 1
+            return .none
+          }
         ),
       environment: MasterEnvironment(
         detail: DetailEnvironment(effect: {
           Empty(completeImmediately: false)
             .handleEvents(
-              receiveSubscription: { _ in didSubscribeToEffect += 1 },
-              receiveCancel: { didCancelEffect += 1 }
+              receiveSubscription: { _ in didFireDetailEffect += 1 },
+              receiveCancel: { didCancelDetailEffect += 1 }
             )
             .eraseToEffect()
         })
@@ -37,92 +99,28 @@ final class ReducerPresentingKeyPathTests: XCTestCase {
       $0.detail = DetailState()
     }
 
-    XCTAssertEqual(didRunPresentedReducer, 0)
-    XCTAssertEqual(didCancelPresentedEffects, 0)
-    XCTAssertEqual(didSubscribeToEffect, 0)
-    XCTAssertEqual(didCancelEffect, 0)
+    XCTAssertEqual(didPresentDetail, 1)
+    XCTAssertEqual(didRunDetailReducer, 0)
+    XCTAssertEqual(didFireDetailEffect, 0)
+    XCTAssertEqual(didDismissDetail, 0)
+    XCTAssertEqual(didCancelDetailEffect, 0)
 
     store.send(.detail(.performEffect))
 
-    XCTAssertEqual(didRunPresentedReducer, 1)
-    XCTAssertEqual(didCancelPresentedEffects, 0)
-    XCTAssertEqual(didSubscribeToEffect, 1)
-    XCTAssertEqual(didCancelEffect, 0)
+    XCTAssertEqual(didPresentDetail, 1)
+    XCTAssertEqual(didRunDetailReducer, 1)
+    XCTAssertEqual(didFireDetailEffect, 1)
+    XCTAssertEqual(didDismissDetail, 0)
+    XCTAssertEqual(didCancelDetailEffect, 0)
 
     store.send(.dismissDetail) {
       $0.detail = nil
     }
 
-    XCTAssertEqual(didRunPresentedReducer, 1)
-    XCTAssertEqual(didCancelPresentedEffects, 1)
-    XCTAssertEqual(didSubscribeToEffect, 1)
-    XCTAssertEqual(didCancelEffect, 1)
-
-    store.send(.dismissDetail)
-
-    XCTAssertEqual(didRunPresentedReducer, 1)
-    XCTAssertEqual(didCancelPresentedEffects, 1)
-    XCTAssertEqual(didSubscribeToEffect, 1)
-    XCTAssertEqual(didCancelEffect, 1)
-  }
-}
-
-// MARK: - Master component
-
-private struct MasterState: Equatable {
-  var detail: DetailState?
-}
-
-private enum MasterAction: Equatable {
-  case presentDetail
-  case dismissDetail
-  case detail(DetailAction)
-}
-
-private struct MasterEnvironment {
-  var detail: DetailEnvironment
-}
-
-private typealias MasterReducer = Reducer<MasterState, MasterAction, MasterEnvironment>
-
-private let masterReducer = MasterReducer { state, action, env in
-  switch action {
-  case .presentDetail:
-    state.detail = DetailState()
-    return .none
-
-  case .dismissDetail:
-    state.detail = nil
-    return .none
-
-  case .detail:
-    return .none
-  }
-}
-
-// MARK: - Detail component
-
-private struct DetailState: Equatable {}
-
-private enum DetailAction: Equatable {
-  case performEffect
-  case didPerformEffect
-}
-
-private struct DetailEnvironment {
-  var effect: () -> Effect<Void, Never>
-}
-
-private typealias DetailReducer = Reducer<DetailState, DetailAction, DetailEnvironment>
-
-private let detailReducer = DetailReducer { state, action, env in
-  switch action {
-  case .performEffect:
-    return env.effect()
-      .map { _ in DetailAction.didPerformEffect }
-      .eraseToEffect()
-
-  case .didPerformEffect:
-    return .none
+    XCTAssertEqual(didPresentDetail, 1)
+    XCTAssertEqual(didRunDetailReducer, 1)
+    XCTAssertEqual(didFireDetailEffect, 1)
+    XCTAssertEqual(didDismissDetail, 1)
+    XCTAssertEqual(didCancelDetailEffect, 1)
   }
 }


### PR DESCRIPTION
Resolves #22 

## Summary

This PR: 

- Replaces `onRun` and `onCancel` callbacks in `Reducer.presenting` extension with `onPresent` and `onDismiss` actions of type `ReducerPresentingAction`.
- Replaces `onRun` and `onCancel` callbacks in `Reducer.presenting(forEach:` extension with `onPresent` and `onDismiss` actions of type  `ReducerPresentingForEachAction`.

## What was done

- [x] Add `ReducerPresentingAction`.
- [x] Update `Reducer.presenting` API.
- [x] Handle `onPresent` and `onDismiss` actions.
