### PR TITLE
Update ComposableArchitecture

### DIFF
--- a/ComposablePresentation.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ComposablePresentation.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/pointfreeco/swift-composable-architecture.git",
         "state": {
           "branch": null,
-          "revision": "599a2398adaaa7a4e3f5420cde7728c39e33677e",
-          "version": "0.28.1"
+          "revision": "ba9c626ab1b2b6af8cf684eebb2ab472fa5b6753",
+          "version": "0.33.1"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/pointfreeco/swift-custom-dump",
         "state": {
           "branch": null,
-          "revision": "21f8fdbb3226e5e28a1a2fffac3e0f3deec34bf0",
-          "version": "0.2.1"
+          "revision": "51698ece74ecf31959d3fa81733f0a5363ef1b4e",
+          "version": "0.3.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     .package(
       name: "swift-composable-architecture",
       url: "https://github.com/pointfreeco/swift-composable-architecture.git",
-      .upToNextMajor(from: "0.28.1")
+      .upToNextMajor(from: "0.33.1")
     ),
   ],
   targets: [

--- a/Sources/ComposablePresentation/Deprecations.swift
+++ b/Sources/ComposablePresentation/Deprecations.swift
@@ -90,5 +90,90 @@ extension Reducer {
       line: line
     )
   }
-}
 
+  /// Combines the reducer with a local reducer that works on elements of `IdentifiedArray`.
+  ///
+  /// - All effects returned by the local reducer when reducing a `LocalState` will be canceled
+  ///   when the `LocalState` is removed from `IdentifiedArray`.
+  /// - Inspired by [Reducer.presents function](https://github.com/pointfreeco/swift-composable-architecture/blob/9ec4b71e5a84f448dedb063a21673e4696ce135f/Sources/ComposableArchitecture/Reducer.swift#L549-L572) from `iso` branch of `swift-composable-architecture` repository.
+  ///
+  /// - Parameters:
+  ///   - localReducer: A reducer that works on `LocalState`, `LocalAction`, `LocalEnvironment`.
+  ///   - toLocalState: A key path from `State` to `IdentifiedArrayOf<LocalState>`.
+  ///   - toLocalAction: A case path that can extract/embed `LocalAction` from `Action`.
+  ///   - toLocalEnvironment: A function that transforms `Environment` into `LocalEnvironment`.
+  ///   - onPresent: An action run when `LocalState` is added to the array. Defaults to an empty action.
+  ///   - onDismiss: An action run when `LocalState` is removed from the array. Defaults to an empty action.
+  ///   - breakpointOnNil: If `true`, raises `SIGTRAP` signal when an action is sent to the reducer but the
+  ///       identified array does not contain an element with the action's identifier. This is
+  ///       generally considered a logic error, as a child reducer cannot process a child action
+  ///       for unavailable child state. Default value is `true`.
+  /// - Returns: A single, combined reducer.
+  @available(*, deprecated, message: """
+  'Reducer.presenting' no longer takes a 'breakpointOnNil' argument.
+  """)
+  public func presenting<LocalState, LocalAction, LocalEnvironment>(
+    forEach localReducer: Reducer<LocalState, LocalAction, LocalEnvironment>,
+    state toLocalState: WritableKeyPath<State, IdentifiedArrayOf<LocalState>>,
+    action toLocalAction: CasePath<Action, (LocalState.ID, LocalAction)>,
+    environment toLocalEnvironment: @escaping (Environment) -> LocalEnvironment,
+    onPresent: ReducerPresentingForEachAction<LocalState.ID, State, Action, Environment> = .empty,
+    onDismiss: ReducerPresentingForEachAction<LocalState.ID, State, Action, Environment> = .empty,
+    breakpointOnNil: Bool = true,
+    file: StaticString = #fileID,
+    line: UInt = #line
+  ) -> Self {
+    presenting(
+      forEach: localReducer,
+      state: toLocalState,
+      action: toLocalAction,
+      environment: toLocalEnvironment,
+      onPresent: onPresent,
+      onDismiss: onDismiss,
+      file: file,
+      line: line
+    )
+  }
+
+  /// Combines the reducer with a local reducer that works on optionally presented `LocalState`.
+  ///
+  /// - All effects returned by the local reducer will be canceled when `LocalState` becomes `nil`.
+  /// - Inspired by [Reducer.presents function](https://github.com/pointfreeco/swift-composable-architecture/blob/9ec4b71e5a84f448dedb063a21673e4696ce135f/Sources/ComposableArchitecture/Reducer.swift#L549-L572) from `iso` branch of `swift-composable-architecture` repository.
+  ///
+  /// - Parameters:
+  ///   - localReducer: A reducer that works on `LocalState`, `LocalAction`, `LocalEnvironment`.
+  ///   - toLocalState: `ReducerPresentingToLocalState` that can get/set `LocalState` inside `State`.
+  ///   - toLocalAction: A case path that can extract/embed `LocalAction` from `Action`.
+  ///   - toLocalEnvironment: A function that transforms `Environment` into `LocalEnvironment`.
+  ///   - onPresent: An action run when `LocalState` is set to an honest value. Defaults to an empty action.
+  ///   - onDismiss: An action run when `LocalState` becomes `nil`. Defaults to an empty action.
+  ///   - breakpointOnNil: If `true`, raises `SIGTRAP` signal when an action is sent to the reducer
+  ///       but state is `nil`. This is generally considered a logic error, as a child reducer cannot
+  ///       process a child action for unavailable child state. Default value is `true`.
+  /// - Returns: A single, combined reducer.
+  @available(*, deprecated, message: """
+  'Reducer.presenting' no longer takes a 'breakpointOnNil' argument.
+  """)
+  public func presenting<LocalState, LocalAction, LocalEnvironment>(
+    _ localReducer: Reducer<LocalState, LocalAction, LocalEnvironment>,
+    state toLocalState: ReducerPresentingToLocalState<State, LocalState>,
+    action toLocalAction: CasePath<Action, LocalAction>,
+    environment toLocalEnvironment: @escaping (Environment) -> LocalEnvironment,
+    onPresent: ReducerPresentingAction<State, Action, Environment> = .empty,
+    onDismiss: ReducerPresentingAction<State, Action, Environment> = .empty,
+    breakpointOnNil: Bool = true,
+    file: StaticString = #fileID,
+    line: UInt = #line
+  ) -> Self {
+    presenting(
+      localReducer,
+      state: toLocalState,
+      action: toLocalAction,
+      environment: toLocalEnvironment,
+      onPresent: onPresent,
+      onDismiss: onDismiss,
+      file: file,
+      line: line
+    )
+  }
+}

--- a/Sources/ComposablePresentation/Reducer+Presenting.swift
+++ b/Sources/ComposablePresentation/Reducer+Presenting.swift
@@ -13,9 +13,6 @@ extension Reducer {
   ///   - toLocalEnvironment: A function that transforms `Environment` into `LocalEnvironment`.
   ///   - onPresent: An action run when `LocalState` is set to an honest value. Defaults to an empty action.
   ///   - onDismiss: An action run when `LocalState` becomes `nil`. Defaults to an empty action.
-  ///   - breakpointOnNil: If `true`, raises `SIGTRAP` signal when an action is sent to the reducer
-  ///       but state is `nil`. This is generally considered a logic error, as a child reducer cannot
-  ///       process a child action for unavailable child state. Default value is `true`.
   /// - Returns: A single, combined reducer.
   public func presenting<LocalState, LocalAction, LocalEnvironment>(
     _ localReducer: Reducer<LocalState, LocalAction, LocalEnvironment>,
@@ -24,7 +21,6 @@ extension Reducer {
     environment toLocalEnvironment: @escaping (Environment) -> LocalEnvironment,
     onPresent: ReducerPresentingAction<State, Action, Environment> = .empty,
     onDismiss: ReducerPresentingAction<State, Action, Environment> = .empty,
-    breakpointOnNil: Bool = true,
     file: StaticString = #fileID,
     line: UInt = #line
   ) -> Self {
@@ -40,7 +36,6 @@ extension Reducer {
         case let .keyPath(keyPath):
           localEffects = localReducer
             .optional(
-              breakpointOnNil: breakpointOnNil,
               file: file,
               line: line
             )
@@ -58,7 +53,6 @@ extension Reducer {
               state: casePath,
               action: toLocalAction,
               environment: toLocalEnvironment,
-              breakpointOnNil: breakpointOnNil,
               file: file,
               line: line
             )

--- a/Sources/ComposablePresentation/Reducer+PresentingForEach.swift
+++ b/Sources/ComposablePresentation/Reducer+PresentingForEach.swift
@@ -14,10 +14,6 @@ extension Reducer {
   ///   - toLocalEnvironment: A function that transforms `Environment` into `LocalEnvironment`.
   ///   - onPresent: An action run when `LocalState` is added to the array. Defaults to an empty action.
   ///   - onDismiss: An action run when `LocalState` is removed from the array. Defaults to an empty action.
-  ///   - breakpointOnNil: If `true`, raises `SIGTRAP` signal when an action is sent to the reducer but the
-  ///       identified array does not contain an element with the action's identifier. This is
-  ///       generally considered a logic error, as a child reducer cannot process a child action
-  ///       for unavailable child state. Default value is `true`.
   /// - Returns: A single, combined reducer.
   public func presenting<LocalState, LocalAction, LocalEnvironment>(
     forEach localReducer: Reducer<LocalState, LocalAction, LocalEnvironment>,
@@ -26,7 +22,6 @@ extension Reducer {
     environment toLocalEnvironment: @escaping (Environment) -> LocalEnvironment,
     onPresent: ReducerPresentingForEachAction<LocalState.ID, State, Action, Environment> = .empty,
     onDismiss: ReducerPresentingForEachAction<LocalState.ID, State, Action, Environment> = .empty,
-    breakpointOnNil: Bool = true,
     file: StaticString = #fileID,
     line: UInt = #line
   ) -> Self {
@@ -53,7 +48,6 @@ extension Reducer {
             state: toLocalState,
             action: toLocalAction,
             environment: toLocalEnvironment,
-            breakpointOnNil: breakpointOnNil,
             file: file,
             line: line
           )


### PR DESCRIPTION
## Summary

This PR updates `ComposableArchitecture` dependency and fixes deprecated usage of  `breakpointOnNil`.

## What was done

- [x] Update `ComposableArchitecture` to v0.33.1.
- [x] Fix deprecated usage of `breakpointOnNil`.
- [x] Deprecate `breakpointOnNil` in `ComposablePresentation`.

