### PR TITLE
Local presented state identification

### DIFF
--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -298,7 +298,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Debug;
@@ -322,7 +322,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Release;

--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		31D7D9BA274096B6001699F4 /* ForEachStoreExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31D7D9B9274096B6001699F4 /* ForEachStoreExample.swift */; };
 		31D7D9BC274099F2001699F4 /* SheetExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31D7D9BB274099F2001699F4 /* SheetExample.swift */; };
 		31D7D9BE27409B99001699F4 /* FullScreenCoverExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31D7D9BD27409B99001699F4 /* FullScreenCoverExample.swift */; };
+		31F8124327C5A2F400AFC10A /* NavigationLinkSelectionExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F8124227C5A2F400AFC10A /* NavigationLinkSelectionExample.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -31,6 +32,7 @@
 		31D7D9B9274096B6001699F4 /* ForEachStoreExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForEachStoreExample.swift; sourceTree = "<group>"; };
 		31D7D9BB274099F2001699F4 /* SheetExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SheetExample.swift; sourceTree = "<group>"; };
 		31D7D9BD27409B99001699F4 /* FullScreenCoverExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullScreenCoverExample.swift; sourceTree = "<group>"; };
+		31F8124227C5A2F400AFC10A /* NavigationLinkSelectionExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationLinkSelectionExample.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -68,6 +70,7 @@
 				31D7D9BB274099F2001699F4 /* SheetExample.swift */,
 				31D7D9BD27409B99001699F4 /* FullScreenCoverExample.swift */,
 				31D7D9B32740907F001699F4 /* NavigationLinkExample.swift */,
+				31F8124227C5A2F400AFC10A /* NavigationLinkSelectionExample.swift */,
 				31D7D9B9274096B6001699F4 /* ForEachStoreExample.swift */,
 				3195775B27415EF100FFA9EB /* PopToRootExample.swift */,
 				3156F63E274253D700CA965F /* SwitchStoreExample.swift */,
@@ -156,6 +159,7 @@
 				31D7D9BC274099F2001699F4 /* SheetExample.swift in Sources */,
 				3156F63F274253D700CA965F /* SwitchStoreExample.swift in Sources */,
 				31D7D9BA274096B6001699F4 /* ForEachStoreExample.swift in Sources */,
+				31F8124327C5A2F400AFC10A /* NavigationLinkSelectionExample.swift in Sources */,
 				3154EC1726DFD41700D69F22 /* App.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/Example/App.swift
+++ b/Example/Example/App.swift
@@ -14,6 +14,7 @@ struct AppView: View {
     case sheetExample
     case fullScreenCoverExample
     case navigationLinkExample
+    case navigationLinkSelectionExample
     case forEachStoreExample
     case popToRootExample
     case switchStoreExample
@@ -39,6 +40,9 @@ struct AppView: View {
 
           case .navigationLinkExample:
             NavigationLinkExample()
+
+          case .navigationLinkSelectionExample:
+            NavigationLinkSelectionExample()
 
           case .forEachStoreExample:
             ForEachStoreExample()

--- a/Example/Example/FullScreenCoverExample.swift
+++ b/Example/Example/FullScreenCoverExample.swift
@@ -30,6 +30,7 @@ struct FullScreenCoverExample: View {
     .presenting(
       detailReducer,
       state: .keyPath(\.detail),
+      id: .notNil(),
       action: /MasterAction.detail,
       environment: { () }
     )

--- a/Example/Example/Info.plist
+++ b/Example/Example/Info.plist
@@ -23,7 +23,7 @@
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>
-		<true/>
+		<false/>
 	</dict>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>

--- a/Example/Example/NavigationLinkExample.swift
+++ b/Example/Example/NavigationLinkExample.swift
@@ -30,6 +30,7 @@ struct NavigationLinkExample: View {
     .presenting(
       detailReducer,
       state: .keyPath(\.detail),
+      id: .notNil(),
       action: /MasterAction.detail,
       environment: { () }
     )

--- a/Example/Example/NavigationLinkExample.swift
+++ b/Example/Example/NavigationLinkExample.swift
@@ -19,7 +19,7 @@ struct NavigationLinkExample: View {
       state.detail = DetailState()
       return .none
 
-    case .didDismissDetail:
+    case .didDismissDetail, .detail(.didTapDismissButton):
       state.detail = nil
       return .none
 
@@ -61,6 +61,7 @@ struct NavigationLinkExample: View {
   }
 
   enum DetailAction {
+    case didTapDismissButton
     case timer(TimerAction)
   }
 
@@ -76,13 +77,19 @@ struct NavigationLinkExample: View {
     let store: Store<DetailState, DetailAction>
 
     var body: some View {
-      TimerView(store: store.scope(
-        state: \.timer,
-        action: DetailAction.timer
-      ))
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(Color(.secondarySystemBackground).ignoresSafeArea())
-        .navigationTitle("Detail")
+      VStack {
+        TimerView(store: store.scope(
+          state: \.timer,
+          action: DetailAction.timer
+        ))
+
+        Button(action: { ViewStore(store.stateless).send(.didTapDismissButton) }) {
+          Text("Dismiss").padding()
+        }
+      }
+      .frame(maxWidth: .infinity, maxHeight: .infinity)
+      .background(Color(.secondarySystemBackground).ignoresSafeArea())
+      .navigationTitle("Detail")
     }
   }
 

--- a/Example/Example/NavigationLinkSelectionExample.swift
+++ b/Example/Example/NavigationLinkSelectionExample.swift
@@ -1,0 +1,148 @@
+import ComposableArchitecture
+import ComposablePresentation
+import SwiftUI
+
+struct NavigationLinkSelectionExample: View {
+  struct Item: Identifiable, Equatable {
+    var id: String
+  }
+
+  struct MasterState {
+    var items: [Item]
+    var detail: DetailState? = nil
+  }
+
+  enum MasterAction {
+    case didSelect(itemId: Item.ID?)
+    case detail(DetailAction)
+  }
+
+  static let masterReducer = Reducer<MasterState, MasterAction, Void> { state, action, _ in
+    switch action {
+    case .didSelect(.some(let itemId)):
+      state.detail = state.items
+        .first { $0.id == itemId }
+        .map(DetailState.init(item:))
+      return .none
+
+    case .didSelect(.none), .detail(.didTapDismissButton):
+      state.detail = nil
+      return .none
+
+    case .detail(_):
+      return .none
+    }
+  }
+    .presenting(
+      detailReducer,
+      state: .keyPath(\.detail),
+      id: .keyPath(\.?.item.id),
+      action: /MasterAction.detail,
+      environment: { () }
+    )
+
+  struct MasterView: View {
+    let store: Store<MasterState, MasterAction>
+
+    struct ViewState: Equatable {
+      let items: [Item]
+      let selectedItemID: Item.ID?
+
+      init(_ state: MasterState) {
+        items = state.items
+        selectedItemID = state.detail?.item.id
+      }
+    }
+
+    var body: some View {
+      WithViewStore(store.scope(state: ViewState.init)) { viewStore in
+        List {
+          ForEach(viewStore.items) { item in
+            NavigationLink(
+              tag: item.id,
+              selection: viewStore.binding(
+                get: \.selectedItemID,
+                send: MasterAction.didSelect
+              ),
+              destination: {
+                IfLetStore(
+                  store.scope(
+                    state: \.detail,
+                    action: MasterAction.detail
+                  ),
+                  then: DetailView.init(store:)
+                )
+              },
+              label: { Text("Item \(item.id)") }
+            )
+          }
+        }
+        .navigationTitle("Master")
+      }
+    }
+  }
+
+  struct DetailState {
+    init(item: Item) {
+      self.item = item
+    }
+
+    var item: Item
+    var timer = TimerState()
+  }
+
+  enum DetailAction {
+    case didTapDismissButton
+    case timer(TimerAction)
+  }
+
+  static let detailReducer = Reducer<DetailState, DetailAction, Void>.combine(
+    timerReducer.pullback(
+      state: \.timer,
+      action: /DetailAction.timer,
+      environment: { () }
+    )
+  )
+
+  struct DetailView: View {
+    let store: Store<DetailState, DetailAction>
+
+    var body: some View {
+      VStack {
+        WithViewStore(store.scope(state: \.item)) { viewStore in
+          Text("Item \(viewStore.id)").padding()
+        }
+
+        TimerView(store: store.scope(
+          state: \.timer,
+          action: DetailAction.timer
+        ))
+
+        Button(action: { ViewStore(store.stateless).send(.didTapDismissButton) }) {
+          Text("Dismiss").padding()
+        }
+      }
+      .navigationTitle("Detail")
+    }
+  }
+
+  var body: some View {
+    NavigationView {
+      MasterView(store: Store(
+        initialState: MasterState(items: [
+          Item(id: "A"),
+          Item(id: "B"),
+          Item(id: "C"),
+        ]),
+        reducer: Self.masterReducer.debug(),
+        environment: ()
+      ))
+    }
+  }
+}
+
+struct NavigationLinkSelectionExample_Previews: PreviewProvider {
+  static var previews: some View {
+    NavigationLinkSelectionExample()
+  }
+}

--- a/Example/Example/PopToRootExample.swift
+++ b/Example/Example/PopToRootExample.swift
@@ -46,6 +46,7 @@ struct PopToRootExample: View {
   ).presenting(
     Self.firstReducer,
     state: .keyPath(\.first),
+    id: .notNil(),
     action: /RootAction.first,
     environment: { () }
   )
@@ -119,6 +120,7 @@ struct PopToRootExample: View {
   ).presenting(
     Self.secondReducer,
     state: .keyPath(\.second),
+    id: .notNil(),
     action: /FirstAction.second,
     environment: { () }
   )

--- a/Example/Example/SheetExample.swift
+++ b/Example/Example/SheetExample.swift
@@ -33,6 +33,7 @@ struct SheetExample: View {
   }.presenting(
     detailReducer,
     state: .keyPath(\.detail),
+    id: .notNil(),
     action: /MasterAction.detail,
     environment: { () }
   )

--- a/Example/Example/SwitchStoreExample.swift
+++ b/Example/Example/SwitchStoreExample.swift
@@ -46,11 +46,13 @@ struct SwitchStoreExample: View {
   }.presenting(
     firstReducer,
     state: .casePath(/MainState.first),
+    id: .notNil(),
     action: /MainAction.first,
     environment: { () }
   ).presenting(
     secondReducer,
     state: .casePath(/MainState.second),
+    id: .notNil(),
     action: /MainAction.second,
     environment: { () }
   )

--- a/Sources/ComposablePresentation/Deprecations.swift
+++ b/Sources/ComposablePresentation/Deprecations.swift
@@ -119,7 +119,7 @@ extension Reducer {
     environment toLocalEnvironment: @escaping (Environment) -> LocalEnvironment,
     onPresent: ReducerPresentingForEachAction<LocalState.ID, State, Action, Environment> = .empty,
     onDismiss: ReducerPresentingForEachAction<LocalState.ID, State, Action, Environment> = .empty,
-    breakpointOnNil: Bool = true,
+    breakpointOnNil: Bool,
     file: StaticString = #fileID,
     line: UInt = #line
   ) -> Self {
@@ -161,7 +161,7 @@ extension Reducer {
     environment toLocalEnvironment: @escaping (Environment) -> LocalEnvironment,
     onPresent: ReducerPresentingAction<State, Action, Environment> = .empty,
     onDismiss: ReducerPresentingAction<State, Action, Environment> = .empty,
-    breakpointOnNil: Bool = true,
+    breakpointOnNil: Bool,
     file: StaticString = #fileID,
     line: UInt = #line
   ) -> Self {

--- a/Sources/ComposablePresentation/Deprecations.swift
+++ b/Sources/ComposablePresentation/Deprecations.swift
@@ -18,7 +18,7 @@ extension Reducer {
   ///       process a child action for unavailable child state. Default value is `true`.
   /// - Returns: A single, combined reducer.
   @available(*, deprecated, message: """
-  Use `Redcuer.presenting` function that takes `ReducerPresentingToLocalState` as `state` parameter.
+  Use `Reducer.presenting` function that takes `ReducerPresentingToLocalState` as `state` parameter.
 
   You can wrap currently passed value with `.keyPath(...)` to fix this warning.
   """)
@@ -63,7 +63,7 @@ extension Reducer {
   ///       process a child action for unavailable child state. Default value is `true`.
   /// - Returns: A single, combined reducer.
   @available(*, deprecated, message: """
-  Use `Redcuer.presenting` function that takes `ReducerPresentingToLocalState` as `state` parameter.
+  Use `Reducer.presenting` function that takes `ReducerPresentingToLocalState` as `state` parameter.
 
   You can wrap currently passed value with `.casePath(...)` to fix this warning.
   """)


### PR DESCRIPTION
## Summary

This PR improves effect cancellation and iPad compatibility.

- Each presented `LocalState` is now identified by its `LocalId`, retrieved using `id` (` ReducerPresentingToLocalId`) parameter passed to `Reducer.presenting` function.
- Whenever `LocalId` of the presented `LocalState?` changes, the effects returned by the local reducer for the previous `LocalId` will be canceled.
- `ReducerPresentingAction.Run` closure now accepts three parameters: `State`, `LocalState` and `Environment`. The `LocalState` is an immutable copy of the dismissed state (for `onDismiss` action) or newly presented state (for `onPresent` action).

The above changes improve support for multi-column `NavigationView` on iPadOS, as well as fixes an issue with effects not being canceled when `LocalState` was replaced by a new one, without making it `nil` first.

## What was done

- [x] Add `ReducerPresentingToLocalId` that returns `LocalId` for provided `LocalState?`.
- [x] Add `LocalState` parameter to `ReducerPresentingAction.Run`.
- [x] Update deprecated APIs.
- [x] Add `NavigationLinkSelectionExample` to iOS example app.
