### PR TITLE
Fix dependency resolver issues

### DIFF
--- a/ComposablePresentation.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ComposablePresentation.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/pointfreeco/swift-composable-architecture.git",
         "state": {
           "branch": null,
-          "revision": "ba9c626ab1b2b6af8cf684eebb2ab472fa5b6753",
-          "version": "0.33.1"
+          "revision": "2828dc44f6e3f81d84bcaba72c1ab1c0121d66f6",
+          "version": "0.34.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     .package(
       name: "swift-composable-architecture",
       url: "https://github.com/pointfreeco/swift-composable-architecture.git",
-      .upToNextMajor(from: "0.33.1")
+      .upToNextMajor(from: "0.34.0")
     ),
   ],
   targets: [


### PR DESCRIPTION
## Summary

For some reason, Swift Package dependency resolving started to fail after the latest release of [ComposableArchitecture](https://github.com/pointfreeco/swift-composable-architecture) library (v0.34.0). Not sure what is causing the problem (probably external changes in the dependency graph), but updating version requirement to the latest version solves it.

## What was done

- [x] Update [ComposableArchitecture](https://github.com/pointfreeco/swift-composable-architecture) requirement to v0.34.0

## Review notes

This should fix the following dependency resolver issue:

> Dependencies could not be resolved because no versions of 'swift-identified-collections' match the requirement 0.3.2..<1.0.0 and root depends on 'swift-composable-architecture' 0.33.1..<1.0.0.
'swift-composable-architecture' >= 0.33.1 practically depends on 'swift-identified-collections' 0.3.2..<1.0.0 because 'swift-composable-architecture' 0.33.1 depends on 'swift-identified-collections' 0.3.2..<1.0.0.
'swift-composable-architecture' >= 0.33.2 practically depends on 'swift-identified-collections' 0.3.2..<1.0.0 because no versions of 'swift-composable-architecture' match the requirement {0.33.2..<0.34.0, 0.34.1..<1.0.0} and 'swift-composable-architecture' 0.34.0 depends on 'swift-identified-collections' 0.3.2..<1.0.0.
