### PR TITLE
Import Foundation and update TCA version 0.39.1

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,70 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "combine-schedulers",
+        "repositoryURL": "https://github.com/pointfreeco/combine-schedulers",
+        "state": {
+          "branch": null,
+          "revision": "9e42b4b0453da417a44daa17174103e7d1c5be07",
+          "version": "0.7.3"
+        }
+      },
+      {
+        "package": "swift-case-paths",
+        "repositoryURL": "https://github.com/pointfreeco/swift-case-paths",
+        "state": {
+          "branch": null,
+          "revision": "a09839348486db8866f85a727b8550be1d671c50",
+          "version": "0.9.1"
+        }
+      },
+      {
+        "package": "swift-collections",
+        "repositoryURL": "https://github.com/apple/swift-collections",
+        "state": {
+          "branch": null,
+          "revision": "48254824bb4248676bf7ce56014ff57b142b77eb",
+          "version": "1.0.2"
+        }
+      },
+      {
+        "package": "swift-composable-architecture",
+        "repositoryURL": "https://github.com/pointfreeco/swift-composable-architecture.git",
+        "state": {
+          "branch": null,
+          "revision": "a518935116b2bada7234f47073159b433d432af1",
+          "version": "0.39.1"
+        }
+      },
+      {
+        "package": "swift-custom-dump",
+        "repositoryURL": "https://github.com/pointfreeco/swift-custom-dump",
+        "state": {
+          "branch": null,
+          "revision": "21ec1d717c07cea5a026979cb0471dd95c7087e7",
+          "version": "0.5.0"
+        }
+      },
+      {
+        "package": "swift-identified-collections",
+        "repositoryURL": "https://github.com/pointfreeco/swift-identified-collections",
+        "state": {
+          "branch": null,
+          "revision": "2d6b7ffcc67afd9077fac5e5a29bcd6d39b71076",
+          "version": "0.4.0"
+        }
+      },
+      {
+        "package": "xctest-dynamic-overlay",
+        "repositoryURL": "https://github.com/pointfreeco/xctest-dynamic-overlay",
+        "state": {
+          "branch": null,
+          "revision": "38bc9242e4388b80bd23ddfdf3071428859e3260",
+          "version": "0.4.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     .package(
       name: "swift-composable-architecture",
       url: "https://github.com/pointfreeco/swift-composable-architecture.git",
-      .upToNextMajor(from: "0.34.0")
+      .upToNextMajor(from: "0.39.1")
     ),
   ],
   targets: [

--- a/Sources/ComposablePresentation/Reducer+Presenting.swift
+++ b/Sources/ComposablePresentation/Reducer+Presenting.swift
@@ -1,4 +1,5 @@
 import ComposableArchitecture
+import Foundation
 
 extension Reducer {
   /// Combines the reducer with a local reducer that works on optionally presented `LocalState`.

--- a/Sources/ComposablePresentation/Reducer+PresentingForEach.swift
+++ b/Sources/ComposablePresentation/Reducer+PresentingForEach.swift
@@ -1,4 +1,5 @@
 import ComposableArchitecture
+import Foundation
 
 extension Reducer {
   /// Combines the reducer with a local reducer that works on elements of `IdentifiedArray`.


### PR DESCRIPTION
Fixed: Pinned combine-schedulers to [0.7.3](https://github.com/pointfreeco/combine-schedulers/releases/0.7.3), which removes an errant @_exported import Foundation. This change may be breaking and require you to add import Foundation in your code.

so import Foundation fixed issue 