### PR TITLE
Adopt ReducerProtocol

### DIFF
--- a/ComposablePresentation.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ComposablePresentation.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/combine-schedulers",
       "state" : {
-        "revision" : "9e42b4b0453da417a44daa17174103e7d1c5be07",
-        "version" : "0.7.3"
+        "revision" : "11973960af9c5426f22d337628cec4342c5e660d",
+        "version" : "0.7.4"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-case-paths",
       "state" : {
-        "revision" : "a09839348486db8866f85a727b8550be1d671c50",
-        "version" : "0.9.1"
+        "revision" : "7346701ea29da0a85d4403cf3d7a589a58ae3dee",
+        "version" : "0.9.2"
       }
     },
     {
@@ -33,7 +33,7 @@
       "location" : "https://github.com/pointfreeco/swift-composable-architecture.git",
       "state" : {
         "branch" : "protocol-beta",
-        "revision" : "083975f2324740286be15fd696a88aa0ef13feaf"
+        "revision" : "79e03e475c67f4e803b8b11bdd4804d01a5193c7"
       }
     },
     {

--- a/ComposablePresentation.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ComposablePresentation.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-composable-architecture.git",
       "state" : {
-        "branch" : "protocol-beta",
-        "revision" : "a7bde3e18b5eda27f9e82e3f149352b2f6c4cd5c"
+        "revision" : "5c476994eaa79af8e466041f6de1ab116f37c528",
+        "version" : "0.42.0"
       }
     },
     {

--- a/ComposablePresentation.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ComposablePresentation.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-case-paths",
       "state" : {
-        "revision" : "7346701ea29da0a85d4403cf3d7a589a58ae3dee",
-        "version" : "0.9.2"
+        "revision" : "15bba50ebf3a2065388c8d12210debe4f6ada202",
+        "version" : "0.10.0"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "c9b6b940d95c0a925c63f6858943415714d8a981",
-        "version" : "0.5.2"
+        "revision" : "819d9d370cd721c9d87671e29d947279292e4541",
+        "version" : "0.6.0"
       }
     },
     {

--- a/ComposablePresentation.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ComposablePresentation.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/combine-schedulers",
       "state" : {
-        "revision" : "11973960af9c5426f22d337628cec4342c5e660d",
-        "version" : "0.7.4"
+        "revision" : "aa3e575929f2bcc5bad012bd2575eae716cbcdf7",
+        "version" : "0.8.0"
       }
     },
     {
@@ -33,7 +33,7 @@
       "location" : "https://github.com/pointfreeco/swift-composable-architecture.git",
       "state" : {
         "branch" : "protocol-beta",
-        "revision" : "79e03e475c67f4e803b8b11bdd4804d01a5193c7"
+        "revision" : "a7bde3e18b5eda27f9e82e3f149352b2f6c4cd5c"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "21ec1d717c07cea5a026979cb0471dd95c7087e7",
-        "version" : "0.5.0"
+        "revision" : "c9b6b940d95c0a925c63f6858943415714d8a981",
+        "version" : "0.5.2"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-identified-collections",
       "state" : {
-        "revision" : "2d6b7ffcc67afd9077fac5e5a29bcd6d39b71076",
-        "version" : "0.4.0"
+        "revision" : "bfb0d43e75a15b6dfac770bf33479e8393884a36",
+        "version" : "0.4.1"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "38bc9242e4388b80bd23ddfdf3071428859e3260",
-        "version" : "0.4.0"
+        "revision" : "30314f1ece684dd60679d598a9b89107557b67d9",
+        "version" : "0.4.1"
       }
     }
   ],

--- a/ComposablePresentation.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ComposablePresentation.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,70 +1,68 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "combine-schedulers",
-        "repositoryURL": "https://github.com/pointfreeco/combine-schedulers",
-        "state": {
-          "branch": null,
-          "revision": "9e42b4b0453da417a44daa17174103e7d1c5be07",
-          "version": "0.7.3"
-        }
-      },
-      {
-        "package": "swift-case-paths",
-        "repositoryURL": "https://github.com/pointfreeco/swift-case-paths",
-        "state": {
-          "branch": null,
-          "revision": "a09839348486db8866f85a727b8550be1d671c50",
-          "version": "0.9.1"
-        }
-      },
-      {
-        "package": "swift-collections",
-        "repositoryURL": "https://github.com/apple/swift-collections",
-        "state": {
-          "branch": null,
-          "revision": "48254824bb4248676bf7ce56014ff57b142b77eb",
-          "version": "1.0.2"
-        }
-      },
-      {
-        "package": "swift-composable-architecture",
-        "repositoryURL": "https://github.com/pointfreeco/swift-composable-architecture.git",
-        "state": {
-          "branch": null,
-          "revision": "a518935116b2bada7234f47073159b433d432af1",
-          "version": "0.39.1"
-        }
-      },
-      {
-        "package": "swift-custom-dump",
-        "repositoryURL": "https://github.com/pointfreeco/swift-custom-dump",
-        "state": {
-          "branch": null,
-          "revision": "21ec1d717c07cea5a026979cb0471dd95c7087e7",
-          "version": "0.5.0"
-        }
-      },
-      {
-        "package": "swift-identified-collections",
-        "repositoryURL": "https://github.com/pointfreeco/swift-identified-collections",
-        "state": {
-          "branch": null,
-          "revision": "2d6b7ffcc67afd9077fac5e5a29bcd6d39b71076",
-          "version": "0.4.0"
-        }
-      },
-      {
-        "package": "xctest-dynamic-overlay",
-        "repositoryURL": "https://github.com/pointfreeco/xctest-dynamic-overlay",
-        "state": {
-          "branch": null,
-          "revision": "38bc9242e4388b80bd23ddfdf3071428859e3260",
-          "version": "0.4.0"
-        }
+  "pins" : [
+    {
+      "identity" : "combine-schedulers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/combine-schedulers",
+      "state" : {
+        "revision" : "9e42b4b0453da417a44daa17174103e7d1c5be07",
+        "version" : "0.7.3"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "swift-case-paths",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-case-paths",
+      "state" : {
+        "revision" : "a09839348486db8866f85a727b8550be1d671c50",
+        "version" : "0.9.1"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections",
+      "state" : {
+        "revision" : "f504716c27d2e5d4144fa4794b12129301d17729",
+        "version" : "1.0.3"
+      }
+    },
+    {
+      "identity" : "swift-composable-architecture",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-composable-architecture.git",
+      "state" : {
+        "branch" : "protocol-beta",
+        "revision" : "083975f2324740286be15fd696a88aa0ef13feaf"
+      }
+    },
+    {
+      "identity" : "swift-custom-dump",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-custom-dump",
+      "state" : {
+        "revision" : "21ec1d717c07cea5a026979cb0471dd95c7087e7",
+        "version" : "0.5.0"
+      }
+    },
+    {
+      "identity" : "swift-identified-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-identified-collections",
+      "state" : {
+        "revision" : "2d6b7ffcc67afd9077fac5e5a29bcd6d39b71076",
+        "version" : "0.4.0"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "38bc9242e4388b80bd23ddfdf3071428859e3260",
+        "version" : "0.4.0"
+      }
+    }
+  ],
+  "version" : 2
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.7
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
   dependencies: [
     .package(
       url: "https://github.com/pointfreeco/swift-composable-architecture.git",
-      .upToNextMajor(from: "0.39.1")
+      branch: "protocol-beta"
     ),
   ],
   targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
   dependencies: [
     .package(
       url: "https://github.com/pointfreeco/swift-composable-architecture.git",
-      branch: "protocol-beta"
+      .upToNextMajor(from: "0.42.0")
     ),
   ],
   targets: [

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Swift Composable Presentation
 
-![Swift v5.6](https://img.shields.io/badge/swift-v5.6-orange.svg)
+![Swift v5.7](https://img.shields.io/badge/swift-v5.7-orange.svg)
 ![platforms iOS, macOS](https://img.shields.io/badge/platforms-iOS,_macOS-blue.svg)
 
 Presentation and navigation helpers for SwiftUI applications build with [ComposableArchitecture](https://github.com/pointfreeco/swift-composable-architecture/).
@@ -69,7 +69,7 @@ SwiftUI example of a component that conditionally presents one of two child comp
 
 ## 🛠 Develop
 
-- Use Xcode (version ≥ 13.4.1).
+- Use Xcode (version ≥ 14).
 - Clone the repository or create a fork & clone it.
 - Open `ComposablePresentation.xcworkspace` in Xcode
 - Use `ComposablePresentation` scheme for building the library and running unit tests.

--- a/Sources/ComposablePresentation/PresentingForEachReducer.swift
+++ b/Sources/ComposablePresentation/PresentingForEachReducer.swift
@@ -3,6 +3,18 @@ import Foundation
 import CoreMedia
 
 extension ReducerProtocol {
+  /// Combines the reducer with another reducer that operates on elements of `IdentifiedArray`.
+  ///
+  /// - All effects returned by the element reducer will be canceled when the element's state is removed from `IdentifiedArray`.
+  /// - Inspired by [Reducer.presents function](https://github.com/pointfreeco/swift-composable-architecture/blob/9ec4b71e5a84f448dedb063a21673e4696ce135f/Sources/ComposableArchitecture/Reducer.swift#L549-L572) from `iso` branch of `swift-composable-architecture` repository.
+  ///
+  /// - Parameters:
+  ///   - state: A key path form parent state to identified array that hold element states.
+  ///   - action: A case path that can extract/embed element action from parent.
+  ///   - onPresent: An action run when element is added to identified array. Defaults to empty action.
+  ///   - onDismiss: An action run when element is removed from identified array. Defaults to empty action.
+  ///   - element: Element reducer.
+  /// - Returns: Combined reducer.
   @inlinable
   public func presentingForEach<ID: Hashable, Element: ReducerProtocol>(
     state toElementState: WritableKeyPath<State, IdentifiedArray<ID, Element.State>>,
@@ -146,9 +158,11 @@ public struct _PresentingForEachReducer<
   }
 }
 
+/// Describes for-each presentation action, like `onPresent` or `onDismiss`.
 public struct PresentingForEachReducerAction<ID, State, Action> {
   public typealias Run = (ID, inout State) -> Effect<Action, Never>
 
+  /// An action that performs no state mutations and returns no effects.
   public static var empty: Self { .init { _, _ in .none } }
 
   public init(run: @escaping Run) {
@@ -158,6 +172,7 @@ public struct PresentingForEachReducerAction<ID, State, Action> {
   public var run: Run
 }
 
+/// Effect produced by element reducer within `.presentingForEach` higher order reducer.
 public struct PresentingForEachReducerEffectID: Hashable {
   @usableFromInline
   let reducerID: UUID

--- a/Sources/ComposablePresentation/PresentingForEachReducer.swift
+++ b/Sources/ComposablePresentation/PresentingForEachReducer.swift
@@ -1,0 +1,173 @@
+import ComposableArchitecture
+import Foundation
+import CoreMedia
+
+extension ReducerProtocol {
+  @inlinable
+  public func presentingForEach<ID: Hashable, Element: ReducerProtocol>(
+    state toElementState: WritableKeyPath<State, IdentifiedArray<ID, Element.State>>,
+    action toElementAction: CasePath<Action, (ID, Element.Action)>,
+    onPresent: PresentingForEachReducerAction<ID, State, Action> = .empty,
+    onDismiss: PresentingForEachReducerAction<ID, State, Action> = .empty,
+    @ReducerBuilderOf<Element> element: () -> Element,
+    file: StaticString = #file,
+    fileID: StaticString = #fileID,
+    line: UInt = #line
+  ) -> _PresentingForEachReducer<Self, ID, Element> {
+    .init(
+      reducerID: UUID(),
+      parent: self,
+      toElementState: toElementState,
+      toElementAction: toElementAction,
+      onPresent: onPresent,
+      onDismiss: onDismiss,
+      element: element(),
+      file: file,
+      fileID: fileID,
+      line: line
+    )
+  }
+}
+
+public struct _PresentingForEachReducer<
+  Parent: ReducerProtocol,
+  ID: Hashable,
+  Element: ReducerProtocol
+>: ReducerProtocol {
+  @usableFromInline
+  let reducerID: UUID
+
+  @usableFromInline
+  let parent: Parent
+
+  @usableFromInline
+  let toElementState: WritableKeyPath<Parent.State, IdentifiedArray<ID, Element.State>>
+
+  @usableFromInline
+  let toElementAction: CasePath<Parent.Action, (ID, Element.Action)>
+
+  @usableFromInline
+  let onPresent: PresentingForEachReducerAction<ID, State, Action>
+
+  @usableFromInline
+  let onDismiss: PresentingForEachReducerAction<ID, State, Action>
+
+  @usableFromInline
+  let element: Element
+
+  @usableFromInline
+  let file: StaticString
+
+  @usableFromInline
+  let fileID: StaticString
+
+  @usableFromInline
+  let line: UInt
+
+  @inlinable
+  init(
+    reducerID: UUID,
+    parent: Parent,
+    toElementState: WritableKeyPath<Parent.State, IdentifiedArray<ID, Element.State>>,
+    toElementAction: CasePath<Parent.Action, (ID, Element.Action)>,
+    onPresent: PresentingForEachReducerAction<ID, State, Action> = .empty,
+    onDismiss: PresentingForEachReducerAction<ID, State, Action> = .empty,
+    element: Element,
+    file: StaticString = #file,
+    fileID: StaticString = #fileID,
+    line: UInt = #line
+  ) {
+    self.reducerID = reducerID
+    self.parent = parent
+    self.toElementState = toElementState
+    self.toElementAction = toElementAction
+    self.onPresent = onPresent
+    self.onDismiss = onDismiss
+    self.element = element
+    self.file = file
+    self.fileID = fileID
+    self.line = line
+  }
+
+  public func reduce(
+    into state: inout Parent.State,
+    action: Parent.Action
+  ) -> Effect<Parent.Action, Never> {
+    func elementID(for action: Action) -> ID? {
+      guard let (id, _) = toElementAction.extract(from: action) else {
+        return nil
+      }
+      return id
+    }
+
+    func effectID(for id: ID) -> PresentingForEachReducerEffectID {
+      .init(reducerID: reducerID, elementID: id)
+    }
+
+    let oldIds = state[keyPath: toElementState].ids
+    let elementEffects: Effect<Action, Never>
+
+    if let id = elementID(for: action) {
+      elementEffects = EmptyReducer()
+        .forEach(
+          toElementState,
+          action: toElementAction,
+          { element },
+          file: file,
+          fileID: fileID,
+          line: line
+        )
+        .reduce(into: &state, action: action)
+        .cancellable(id: effectID(for: id))
+    } else {
+      elementEffects = .none
+    }
+
+    let parentEffects = parent.reduce(into: &state, action: action)
+    let newIds = state[keyPath: toElementState].ids
+    let presentedIds = newIds.subtracting(oldIds)
+    let dismissedIds = oldIds.subtracting(newIds)
+    var presentationEffects: [Effect<Action, Never>] = []
+
+    dismissedIds.forEach { id in
+      presentationEffects.append(onDismiss.run(id, &state))
+      presentationEffects.append(.cancel(id: effectID(for: id)))
+    }
+
+    presentedIds.forEach { id in
+      presentationEffects.append(onPresent.run(id, &state))
+    }
+
+    return .merge(
+      elementEffects,
+      parentEffects,
+      .merge(presentationEffects)
+    )
+  }
+}
+
+public struct PresentingForEachReducerAction<ID, State, Action> {
+  public typealias Run = (ID, inout State) -> Effect<Action, Never>
+
+  public static var empty: Self { .init { _, _ in .none } }
+
+  public init(run: @escaping Run) {
+    self.run = run
+  }
+
+  public var run: Run
+}
+
+public struct PresentingForEachReducerEffectID: Hashable {
+  @usableFromInline
+  let reducerID: UUID
+
+  @usableFromInline
+  let elementID: AnyHashable
+
+  @inlinable
+  init(reducerID: UUID, elementID: AnyHashable) {
+    self.reducerID = reducerID
+    self.elementID = elementID
+  }
+}

--- a/Sources/ComposablePresentation/PresentingReducer.swift
+++ b/Sources/ComposablePresentation/PresentingReducer.swift
@@ -1,0 +1,233 @@
+import ComposableArchitecture
+import Foundation
+
+extension ReducerProtocol {
+  @inlinable
+  public func presenting<Presented, PresentedID>(
+    state toPresentedState: PresentingReducerToPresentedState<State, Presented.State>,
+    id toPresentedId: PresentingReducerToPresentedId<Presented.State, PresentedID>,
+    action toPresentedAction: CasePath<Action, Presented.Action>,
+    onPresent: PresentingReducerAction<State, Presented.State, Action> = .empty,
+    onDismiss: PresentingReducerAction<State, Presented.State, Action> = .empty,
+    @ReducerBuilderOf<Presented> presented: () -> Presented,
+    file: StaticString = #file,
+    fileID: StaticString = #fileID,
+    line: UInt = #line
+  ) -> _PresentingReducer<Self, Presented, PresentedID>
+  where Presented: ReducerProtocol,
+        PresentedID: Hashable
+  {
+    .init(
+      reducerId: UUID(),
+      parent: self,
+      presented: presented(),
+      toPresentedState: toPresentedState,
+      toPresentedId: toPresentedId,
+      toPresentedAction: toPresentedAction,
+      onPresent: onPresent,
+      onDismiss: onDismiss,
+      file: file,
+      fileID: fileID,
+      line: line
+    )
+  }
+}
+
+public struct _PresentingReducer<Parent, Presented, PresentedID>: ReducerProtocol
+where Parent: ReducerProtocol,
+      Presented: ReducerProtocol,
+      PresentedID: Hashable
+{
+  @usableFromInline
+  let reducerId: UUID
+
+  @usableFromInline
+  let parent: Parent
+
+  @usableFromInline
+  let presented: Presented
+
+  @usableFromInline
+  let toPresentedState: PresentingReducerToPresentedState<Parent.State, Presented.State>
+
+  @usableFromInline
+  let toPresentedId: PresentingReducerToPresentedId<Presented.State, PresentedID>
+
+  @usableFromInline
+  let toPresentedAction: CasePath<Parent.Action, Presented.Action>
+
+  @usableFromInline
+  let onPresent: PresentingReducerAction<Parent.State, Presented.State, Parent.Action>
+
+  @usableFromInline
+  let onDismiss: PresentingReducerAction<Parent.State, Presented.State, Parent.Action>
+
+  @usableFromInline
+  let file: StaticString
+
+  @usableFromInline
+  let fileID: StaticString
+
+  @usableFromInline
+  let line: UInt
+
+  @inlinable
+  init(
+    reducerId: UUID,
+    parent: Parent,
+    presented: Presented,
+    toPresentedState: PresentingReducerToPresentedState<Parent.State, Presented.State>,
+    toPresentedId: PresentingReducerToPresentedId<Presented.State, PresentedID>,
+    toPresentedAction: CasePath<Parent.Action, Presented.Action>,
+    onPresent: PresentingReducerAction<Parent.State, Presented.State, Parent.Action>,
+    onDismiss: PresentingReducerAction<Parent.State, Presented.State, Parent.Action>,
+    file: StaticString,
+    fileID: StaticString,
+    line: UInt
+  ) {
+    self.reducerId = reducerId
+    self.parent = parent
+    self.presented = presented
+    self.toPresentedState = toPresentedState
+    self.toPresentedId = toPresentedId
+    self.toPresentedAction = toPresentedAction
+    self.onPresent = onPresent
+    self.onDismiss = onDismiss
+    self.file = file
+    self.fileID = fileID
+    self.line = line
+  }
+
+  @inlinable
+  public func reduce(
+    into state: inout Parent.State,
+    action: Parent.Action
+  ) -> Effect<Parent.Action, Never> {
+    let oldState = state
+    let oldPresentedState = toPresentedState(oldState)
+    let oldPresentedId = toPresentedId(oldPresentedState)
+
+    let presentedEffectsId = PresentingReducerEffectId(
+      reducerID: reducerId,
+      presentedID: oldPresentedId
+    )
+    let shouldRunPresented = toPresentedAction.extract(from: action) != nil
+    let presentedEffects: Effect<Action, Never>
+    if shouldRunPresented {
+      switch toPresentedState {
+      case let .keyPath(keyPath):
+        presentedEffects = EmptyReducer()
+          .ifLet(
+            keyPath,
+            action: toPresentedAction,
+            then: { presented },
+            file: file,
+            fileID: fileID,
+            line: line
+          )
+          .reduce(into: &state, action: action)
+          .cancellable(id: presentedEffectsId)
+
+      case let .casePath(casePath):
+        presentedEffects = EmptyReducer()
+          .ifCaseLet(
+            casePath,
+            action: toPresentedAction,
+            then: { presented },
+            file: file,
+            fileID: fileID,
+            line: line
+          )
+          .reduce(into: &state, action: action)
+          .cancellable(id: presentedEffectsId)
+      }
+    } else {
+      presentedEffects = .none
+    }
+
+    let effects = parent.reduce(into: &state, action: action)
+    let newState = state
+    let newPresentedState = toPresentedState(newState)
+    let newPresentedId = toPresentedId(newPresentedState)
+
+    var presentationEffects: [Effect<Action, Never>] = []
+    if oldPresentedId != newPresentedId {
+      if let oldPresentedState = oldPresentedState {
+        presentationEffects.append(onDismiss.run(&state, oldPresentedState))
+        presentationEffects.append(.cancel(id: presentedEffectsId))
+      }
+      if let newPresentedState = newPresentedState {
+        presentationEffects.append(onPresent.run(&state, newPresentedState))
+      }
+    }
+
+    return .merge(
+      presentedEffects,
+      effects,
+      .merge(presentationEffects)
+    )
+  }
+}
+
+public enum PresentingReducerToPresentedState<State, PresentedState> {
+  case keyPath(WritableKeyPath<State, PresentedState?>)
+
+  case casePath(CasePath<State, PresentedState>)
+
+  public func callAsFunction(_ state: State) -> PresentedState? {
+    switch self {
+    case let .keyPath(keyPath):
+      return state[keyPath: keyPath]
+    case let .casePath(casePath):
+      return casePath.extract(from: state)
+    }
+  }
+}
+
+public struct PresentingReducerToPresentedId<State, ID: Hashable> {
+  public typealias Run = (State?) -> ID
+
+  public static func notNil<State>() -> PresentingReducerToPresentedId<State, Bool> {
+    .init { $0 != nil }
+  }
+
+  public static func keyPath(_ keyPath: KeyPath<State?, ID>) -> PresentingReducerToPresentedId<State, ID> {
+    .init { $0[keyPath: keyPath] }
+  }
+
+  public init(run: @escaping Run) {
+    self.run = run
+  }
+
+  public var run: Run
+
+  public func callAsFunction(_ state: State?) -> ID {
+    run(state)
+  }
+}
+
+public struct PresentingReducerAction<State, ChildState, Action> {
+  public typealias Run = (inout State, ChildState) -> Effect<Action, Never>
+
+  public static var empty: Self { .init { _, _ in .none } }
+
+  public init(run: @escaping Run) {
+    self.run = run
+  }
+
+  public var run: Run
+}
+
+public struct PresentingReducerEffectId<PresentedID: Hashable>: Hashable {
+  @usableFromInline
+  let reducerID: UUID
+
+  @usableFromInline
+  let presentedID: PresentedID
+
+  @inlinable
+  init(reducerID: UUID, presentedID: PresentedID) {
+    self.reducerID = reducerID
+    self.presentedID = presentedID
+  }
+}

--- a/Sources/ComposablePresentation/Reducer+Presenting.swift
+++ b/Sources/ComposablePresentation/Reducer+Presenting.swift
@@ -15,6 +15,16 @@ extension Reducer {
   ///   - onPresent: An action run when `LocalState` is set to an honest value. It takes current `State`, new `LocalState`, and `Environment` as parameters and returns `Effect<Action, Never>`. Defaults to an empty action.
   ///   - onDismiss: An action run when `LocalState` becomes `nil`. It takes current `State`, old `LocalState`, and `Environment` as parameters and returns `Effect<Action, Never>`. Defaults to an empty action.
   /// - Returns: A single, combined reducer.
+  @available(
+    iOS,
+    deprecated: 9999.0,
+    message: "This API has been soft-deprecated in favor of `ReducerProtocol.presenting`."
+  )
+  @available(
+    macOS,
+    deprecated: 9999.0,
+    message: "This API has been soft-deprecated in favor of `ReducerProtocol.presenting`."
+  )
   public func presenting<LocalState, LocalID: Hashable, LocalAction, LocalEnvironment>(
     _ localReducer: Reducer<LocalState, LocalAction, LocalEnvironment>,
     state toLocalState: ReducerPresentingToLocalState<State, LocalState>,

--- a/Sources/ComposablePresentation/Reducer+Presenting.swift
+++ b/Sources/ComposablePresentation/Reducer+Presenting.swift
@@ -34,76 +34,36 @@ extension Reducer {
     onPresent: ReducerPresentingAction<State, LocalState, Action, Environment> = .empty,
     onDismiss: ReducerPresentingAction<State, LocalState, Action, Environment> = .empty,
     file: StaticString = #fileID,
+    fileID: StaticString = #fileID,
     line: UInt = #line
   ) -> Self {
     let reducerId = UUID()
-    return Reducer { state, action, environment in
-      let oldState = state
-      let oldLocalState = toLocalState(oldState)
-      let oldLocalId = toLocalId(oldLocalState)
-
-      let shouldRunLocal = toLocalAction.extract(from: action) != nil
-      let localEffects: Effect<Action, Never>
-      if shouldRunLocal {
-        let localEffectsId = ReducerPresentingEffectId(
-          reducerID: reducerId,
-          localID: toLocalId.run(toLocalState(oldState))
-        )
-        switch toLocalState {
-        case let .keyPath(keyPath):
-          localEffects = localReducer
-            .optional(
-              file: file,
-              line: line
-            )
-            .pullback(
-              state: keyPath,
-              action: toLocalAction,
-              environment: toLocalEnvironment
-            )
-            .run(&state, action, environment)
-            .cancellable(id: localEffectsId)
-
-        case let .casePath(casePath):
-          localEffects = localReducer
-            .pullback(
-              state: casePath,
-              action: toLocalAction,
-              environment: toLocalEnvironment,
-              file: file,
-              line: line
-            )
-            .run(&state, action, environment)
-            .cancellable(id: localEffectsId)
-        }
-      } else {
-        localEffects = .none
-      }
-
-      let effects = self.run(&state, action, environment)
-      let newState = state
-      let newLocalState = toLocalState(newState)
-      let newLocalId = toLocalId(newLocalState)
-      
-      var presentationEffects: [Effect<Action, Never>] = []
-      if oldLocalId != newLocalId {
-        if let oldLocalState = oldLocalState {
-          presentationEffects.append(onDismiss.run(&state, oldLocalState, environment))
-          presentationEffects.append(.cancel(id: ReducerPresentingEffectId(
-            reducerID: reducerId,
-            localID: oldLocalId
-          )))
-        }
-        if let newLocalState = newLocalState {
-          presentationEffects.append(onPresent.run(&state, newLocalState, environment))
-        }
-      }
-
-      return .merge(
-        localEffects,
-        effects,
-        .merge(presentationEffects)
+    return Reducer { state, action, env in
+      _PresentingReducer(
+        reducerID: reducerId,
+        parent: Reduce(AnyReducer(self.run), environment: env),
+        presented: Reduce { state, action in
+          localReducer.run(&state, action, toLocalEnvironment(env))
+        },
+        toPresentedState: {
+          switch toLocalState {
+          case .keyPath(let keyPath): return .keyPath(keyPath)
+          case .casePath(let casePath): return .casePath(casePath)
+          }
+        }(),
+        toPresentedID: .init(run: toLocalId.run),
+        toPresentedAction: toLocalAction,
+        onPresent: .init { state, presentedState in
+          onPresent.run(&state, presentedState, env)
+        },
+        onDismiss: .init { state, presentedState in
+          onDismiss.run(&state, presentedState, env)
+        },
+        file: file,
+        fileID: fileID,
+        line: line
       )
+      .reduce(into: &state, action: action)
     }
   }
 }
@@ -178,9 +138,4 @@ public struct ReducerPresentingAction<State, LocalState, Action, Environment> {
   }
 
   public var run: Run
-}
-
-struct ReducerPresentingEffectId<LocalID: Hashable>: Hashable {
-  let reducerID: UUID
-  let localID: LocalID
 }

--- a/Sources/ComposablePresentation/Reducer+PresentingForEach.swift
+++ b/Sources/ComposablePresentation/Reducer+PresentingForEach.swift
@@ -34,60 +34,27 @@ extension Reducer {
     onPresent: ReducerPresentingForEachAction<LocalState.ID, State, Action, Environment> = .empty,
     onDismiss: ReducerPresentingForEachAction<LocalState.ID, State, Action, Environment> = .empty,
     file: StaticString = #fileID,
+    fileID: StaticString = #fileID,
     line: UInt = #line
   ) -> Self {
-    let presentationId = UUID()
-
-    func elementId(for action: Action) -> LocalState.ID? {
-      guard let (id, _) = toLocalAction.extract(from: action) else {
-        return nil
-      }
-      return id
-    }
-
-    func effectId(for id: LocalState.ID) -> ReducerPresentingForEachEffectId {
-      .init(presentationId: presentationId, elementId: id)
-    }
-
-    return Reducer { state, action, environment in
-      let oldIds = state[keyPath: toLocalState].ids
-      let localEffects: Effect<Action, Never>
-
-      if let id = elementId(for: action) {
-        localEffects = localReducer
-          .forEach(
-            state: toLocalState,
-            action: toLocalAction,
-            environment: toLocalEnvironment,
-            file: file,
-            line: line
-          )
-          .run(&state, action, environment)
-          .cancellable(id: effectId(for: id))
-      } else {
-        localEffects = .none
-      }
-
-      let effects = run(&state, action, environment)
-      let newIds = state[keyPath: toLocalState].ids
-      let presentedIds = newIds.subtracting(oldIds)
-      let dismissedIds = oldIds.subtracting(newIds)
-      var presentationEffects: [Effect<Action, Never>] = []
-
-      dismissedIds.forEach { id in
-        presentationEffects.append(onDismiss.run(id, &state, environment))
-        presentationEffects.append(.cancel(id: effectId(for: id)))
-      }
-
-      presentedIds.forEach { id in
-        presentationEffects.append(onPresent.run(id, &state, environment))
-      }
-
-      return .merge(
-        localEffects,
-        effects,
-        .merge(presentationEffects)
+    let reducerId = UUID()
+    return Reducer { state, action, env in
+      _PresentingForEachReducer(
+        reducerID: reducerId,
+        parent: Reduce(AnyReducer(self.run), environment: env),
+        toElementState: toLocalState,
+        toElementAction: toLocalAction,
+        onPresent: .init { elementId, state in
+          onPresent.run(elementId, &state, env)
+        },
+        onDismiss: .init { elementId, state in
+          onDismiss.run(elementId, &state, env)
+        },
+        element: Reduce { state, action in
+          localReducer.run(&state, action, toLocalEnvironment(env))
+        }
       )
+      .reduce(into: &state, action: action)
     }
   }
 }
@@ -104,9 +71,4 @@ public struct ReducerPresentingForEachAction<ID, State, Action, Environment> {
   }
 
   public var run: Run
-}
-
-struct ReducerPresentingForEachEffectId: Hashable {
-  var presentationId: UUID
-  var elementId: AnyHashable
 }

--- a/Sources/ComposablePresentation/Reducer+PresentingForEach.swift
+++ b/Sources/ComposablePresentation/Reducer+PresentingForEach.swift
@@ -16,6 +16,16 @@ extension Reducer {
   ///   - onPresent: An action run when `LocalState` is added to the array. Defaults to an empty action.
   ///   - onDismiss: An action run when `LocalState` is removed from the array. Defaults to an empty action.
   /// - Returns: A single, combined reducer.
+  @available(
+    iOS,
+    deprecated: 9999.0,
+    message: "This API has been soft-deprecated in favor of `ReducerProtocol.presentingForEach`."
+  )
+  @available(
+    macOS,
+    deprecated: 9999.0,
+    message: "This API has been soft-deprecated in favor of `ReducerProtocol.presentingForEach`."
+  )
   public func presenting<LocalState, LocalAction, LocalEnvironment>(
     forEach localReducer: Reducer<LocalState, LocalAction, LocalEnvironment>,
     state toLocalState: WritableKeyPath<State, IdentifiedArrayOf<LocalState>>,

--- a/Tests/ComposablePresentationTests/PresentingForEachReducerTests.swift
+++ b/Tests/ComposablePresentationTests/PresentingForEachReducerTests.swift
@@ -1,0 +1,156 @@
+import Combine
+import ComposableArchitecture
+import XCTest
+@testable import ComposablePresentation
+
+final class PresentingForEachReducerTests: XCTestCase {
+  func testPresentingWithIdentifiedArray() {
+    var didPresent = [Element.State.ID]()
+    var didRun = [Element.State.ID]()
+    var didFireEffect = [Element.State.ID]()
+    var didDismiss = [Element.State.ID]()
+    var didCancelEffect = [Element.State.ID]()
+
+    struct Parent: ReducerProtocol {
+      struct State: Equatable {
+        var elements: IdentifiedArrayOf<Element.State>
+      }
+
+      enum Action: Equatable {
+        case addElement(id: Int)
+        case removeElement(id: Int)
+        case element(id: Int, action: Element.Action)
+      }
+
+      func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+        switch action {
+        case .addElement(let id):
+          state.elements.append(Element.State(id: id))
+          return .none
+
+        case .removeElement(let id):
+          _ = state.elements.remove(id: id)
+          return .none
+
+        case .element(_, _):
+          return .none
+        }
+      }
+    }
+
+    struct Element: ReducerProtocol {
+      struct State: Equatable, Identifiable {
+        var id: Int
+      }
+
+      enum Action: Equatable {
+        case performEffect
+        case didPerformEffect
+      }
+
+      var effect: (State.ID) -> Effect<Void, Never>
+      var onReduce: (State.ID) -> Void
+
+      func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+        onReduce(state.id)
+        switch action {
+        case .performEffect:
+          return effect(state.id)
+            .map { _ in .didPerformEffect }
+            .eraseToEffect()
+
+        case .didPerformEffect:
+          return .none
+        }
+      }
+    }
+
+    let store = TestStore(
+      initialState: Parent.State(elements: []),
+      reducer: Parent()
+        .presentingForEach(
+          state: \.elements,
+          action: /Parent.Action.element(id:action:),
+          onPresent: .init { id, _ in
+            didPresent.append(id)
+            return .none
+          },
+          onDismiss: .init { id, _ in
+            didDismiss.append(id)
+            return .none
+          },
+          element: {
+            Element(
+              effect: { id in
+                Empty(completeImmediately: false)
+                  .handleEvents(
+                    receiveSubscription: { _ in didFireEffect.append(id) },
+                    receiveCancel: { didCancelEffect.append(id) }
+                  )
+                  .eraseToEffect()
+              },
+              onReduce: { id in
+                didRun.append(id)
+              }
+            )
+          }
+        )
+    )
+
+    store.send(.addElement(id: 1)) {
+      $0.elements.append(Element.State(id: 1))
+    }
+
+    XCTAssertEqual(didPresent, [1])
+    XCTAssertEqual(didRun, [])
+    XCTAssertEqual(didFireEffect, [])
+    XCTAssertEqual(didDismiss, [])
+    XCTAssertEqual(didCancelEffect, [])
+
+    store.send(.element(id: 1, action: .performEffect))
+
+    XCTAssertEqual(didPresent, [1])
+    XCTAssertEqual(didRun, [1])
+    XCTAssertEqual(didFireEffect, [1])
+    XCTAssertEqual(didDismiss, [])
+    XCTAssertEqual(didCancelEffect, [])
+
+    store.send(.addElement(id: 2)) {
+      $0.elements.append(Element.State(id: 2))
+    }
+
+    XCTAssertEqual(didPresent, [1, 2])
+    XCTAssertEqual(didRun, [1])
+    XCTAssertEqual(didFireEffect, [1])
+    XCTAssertEqual(didDismiss, [])
+    XCTAssertEqual(didCancelEffect, [])
+
+    store.send(.element(id: 2, action: .performEffect))
+
+    XCTAssertEqual(didPresent, [1, 2])
+    XCTAssertEqual(didRun, [1, 2])
+    XCTAssertEqual(didFireEffect, [1, 2])
+    XCTAssertEqual(didDismiss, [])
+    XCTAssertEqual(didCancelEffect, [])
+
+    store.send(.removeElement(id: 1)) {
+      $0.elements.remove(id: 1)
+    }
+
+    XCTAssertEqual(didPresent, [1, 2])
+    XCTAssertEqual(didRun, [1, 2])
+    XCTAssertEqual(didFireEffect, [1, 2])
+    XCTAssertEqual(didDismiss, [1])
+    XCTAssertEqual(didCancelEffect, [1])
+
+    store.send(.removeElement(id: 2)) {
+      $0.elements.remove(id: 2)
+    }
+
+    XCTAssertEqual(didPresent, [1, 2])
+    XCTAssertEqual(didRun, [1, 2])
+    XCTAssertEqual(didFireEffect, [1, 2])
+    XCTAssertEqual(didDismiss, [1, 2])
+    XCTAssertEqual(didCancelEffect, [1, 2])
+  }
+}

--- a/Tests/ComposablePresentationTests/PresentingReducerTests.swift
+++ b/Tests/ComposablePresentationTests/PresentingReducerTests.swift
@@ -1,0 +1,472 @@
+import CasePaths
+import Combine
+import ComposableArchitecture
+import XCTest
+@testable import ComposablePresentation
+
+final class PresentingReducerTests: XCTestCase {
+  func testPresentingWithKeyPath() {
+    var didPresentChild = 0
+    var didRunChildReducer = 0
+    var didFireChildEffect = 0
+    var didDismissChild = 0
+    var didCancelChildEffect = 0
+
+    struct Parent: ReducerProtocol {
+      struct State: Equatable {
+        var child: Child.State?
+      }
+
+      enum Action: Equatable {
+        case presentChild
+        case dismissChild
+        case child(Child.Action)
+      }
+
+      func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+        switch action {
+        case .presentChild:
+          state.child = Child.State()
+          return .none
+
+        case .dismissChild:
+          state.child = nil
+          return .none
+
+        case .child:
+          return .none
+        }
+      }
+    }
+
+    struct Child: ReducerProtocol {
+      struct State: Equatable {}
+
+      enum Action: Equatable {
+        case performEffect
+        case didPerformEffect
+      }
+
+      var effect: () -> Effect<Void, Never>
+      var onReduce: () -> Void
+
+      func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+        onReduce()
+        switch action {
+        case .performEffect:
+          return effect()
+            .map { _ in .didPerformEffect }
+            .eraseToEffect()
+
+        case .didPerformEffect:
+          return .none
+        }
+      }
+    }
+
+    let store = TestStore(
+      initialState: Parent.State(),
+      reducer: Parent()
+        .presenting(
+          state: .keyPath(\.child),
+          id: .notNil(),
+          action: /Parent.Action.child,
+          onPresent: .init { _, _ in
+            didPresentChild += 1
+            return .none
+          },
+          onDismiss: .init { _, _ in
+            didDismissChild += 1
+            return .none
+          },
+          presented: {
+            Child(
+              effect: {
+                Empty(completeImmediately: false)
+                  .handleEvents(
+                    receiveSubscription: { _ in didFireChildEffect += 1 },
+                    receiveCancel: { didCancelChildEffect += 1 }
+                  )
+                  .eraseToEffect()
+              },
+              onReduce: { didRunChildReducer += 1 }
+            )
+          }
+        )
+    )
+
+    store.send(.presentChild) {
+      $0.child = Child.State()
+    }
+
+    XCTAssertEqual(didPresentChild, 1)
+    XCTAssertEqual(didRunChildReducer, 0)
+    XCTAssertEqual(didFireChildEffect, 0)
+    XCTAssertEqual(didDismissChild, 0)
+    XCTAssertEqual(didCancelChildEffect, 0)
+
+    store.send(.child(.performEffect))
+
+    XCTAssertEqual(didPresentChild, 1)
+    XCTAssertEqual(didRunChildReducer, 1)
+    XCTAssertEqual(didFireChildEffect, 1)
+    XCTAssertEqual(didDismissChild, 0)
+    XCTAssertEqual(didCancelChildEffect, 0)
+
+    store.send(.dismissChild) {
+      $0.child = nil
+    }
+
+    XCTAssertEqual(didPresentChild, 1)
+    XCTAssertEqual(didRunChildReducer, 1)
+    XCTAssertEqual(didFireChildEffect, 1)
+    XCTAssertEqual(didDismissChild, 1)
+    XCTAssertEqual(didCancelChildEffect, 1)
+  }
+
+  func testPresentingWithCasePath() {
+    var didPresentFirst = 0
+    var didRunFirstReducer = 0
+    var didFireFirstEffect = 0
+    var didDismissFirst = 0
+    var didCancelFirstEffect = 0
+
+    var didPresentSecond = 0
+    var didRunSecondReducer = 0
+    var didFireSecondEffect = 0
+    var didDismissSecond = 0
+    var didCancelSecondEffect = 0
+
+    struct Parent: ReducerProtocol {
+      enum State: Equatable {
+        case first(First.State)
+        case second(Second.State)
+      }
+
+      enum Action: Equatable {
+        case presentFirst
+        case presentSecond
+        case first(First.Action)
+        case second(Second.Action)
+      }
+
+      func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+        switch action {
+        case .presentFirst:
+          state = .first(First.State())
+          return .none
+
+        case .presentSecond:
+          state = .second(Second.State())
+          return .none
+
+        case .first(_), .second(_):
+          return .none
+        }
+      }
+    }
+
+    struct First: ReducerProtocol {
+      struct State: Equatable {}
+
+      enum Action: Equatable {
+        case performEffect
+        case didPerformEffect
+      }
+
+      var effect: () -> Effect<Void, Never>
+      var onReduce: () -> Void
+
+      func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+        onReduce()
+        switch action {
+        case .performEffect:
+          return effect()
+            .map { _ in .didPerformEffect }
+            .eraseToEffect()
+
+        case .didPerformEffect:
+          return .none
+        }
+      }
+    }
+
+    struct Second: ReducerProtocol {
+      struct State: Equatable {}
+
+      enum Action: Equatable {
+        case performEffect
+        case didPerformEffect
+      }
+
+      var effect: () -> Effect<Void, Never>
+      var onReduce: () -> Void
+
+      func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+        onReduce() // didRunSecondReducer += 1
+        switch action {
+        case .performEffect:
+          return effect()
+            .map { _ in .didPerformEffect }
+            .eraseToEffect()
+
+        case .didPerformEffect:
+          return .none
+        }
+      }
+    }
+
+    let store = TestStore(
+      initialState: Parent.State.first(First.State()),
+      reducer: Parent()
+        .presenting(
+          state: .casePath(/Parent.State.first),
+          id: .notNil(),
+          action: /Parent.Action.first,
+          onPresent: .init { _, _ in
+            didPresentFirst += 1
+            return .none
+          },
+          onDismiss: .init { _, _ in
+            didDismissFirst += 1
+            return .none
+          },
+          presented: {
+            First(
+              effect: {
+                Empty(completeImmediately: false)
+                  .handleEvents(
+                    receiveSubscription: { _ in didFireFirstEffect += 1 },
+                    receiveCancel: { didCancelFirstEffect += 1 }
+                  )
+                  .eraseToEffect()
+              },
+              onReduce: {
+                didRunFirstReducer += 1
+              }
+            )
+          }
+        )
+        .presenting(
+          state: .casePath(/Parent.State.second),
+          id: .notNil(),
+          action: /Parent.Action.second,
+          onPresent: .init { _, _ in
+            didPresentSecond += 1
+            return .none
+          },
+          onDismiss: .init { _, _ in
+            didDismissSecond += 1
+            return .none
+          },
+          presented: {
+            Second(
+              effect: {
+                Empty(completeImmediately: false)
+                  .handleEvents(
+                    receiveSubscription: { _ in didFireSecondEffect += 1 },
+                    receiveCancel: { didCancelSecondEffect += 1 }
+                  )
+                  .eraseToEffect()
+              },
+              onReduce: {
+                didRunSecondReducer += 1
+              }
+            )
+          }
+        )
+    )
+
+    store.send(.first(.performEffect))
+
+    XCTAssertEqual(didPresentFirst, 0)
+    XCTAssertEqual(didRunFirstReducer, 1)
+    XCTAssertEqual(didFireFirstEffect, 1)
+    XCTAssertEqual(didDismissFirst, 0)
+    XCTAssertEqual(didCancelFirstEffect, 0)
+
+    XCTAssertEqual(didPresentSecond, 0)
+    XCTAssertEqual(didRunSecondReducer, 0)
+    XCTAssertEqual(didFireSecondEffect, 0)
+    XCTAssertEqual(didDismissSecond, 0)
+    XCTAssertEqual(didCancelSecondEffect, 0)
+
+    store.send(.presentSecond) {
+      $0 = .second(Second.State())
+    }
+
+    XCTAssertEqual(didPresentFirst, 0)
+    XCTAssertEqual(didRunFirstReducer, 1)
+    XCTAssertEqual(didFireFirstEffect, 1)
+    XCTAssertEqual(didDismissFirst, 1)
+    XCTAssertEqual(didCancelFirstEffect, 1)
+
+    XCTAssertEqual(didPresentSecond, 1)
+    XCTAssertEqual(didRunSecondReducer, 0)
+    XCTAssertEqual(didFireSecondEffect, 0)
+    XCTAssertEqual(didDismissSecond, 0)
+    XCTAssertEqual(didCancelSecondEffect, 0)
+
+    store.send(.second(.performEffect))
+
+    XCTAssertEqual(didPresentFirst, 0)
+    XCTAssertEqual(didRunFirstReducer, 1)
+    XCTAssertEqual(didFireFirstEffect, 1)
+    XCTAssertEqual(didDismissFirst, 1)
+    XCTAssertEqual(didCancelFirstEffect, 1)
+
+    XCTAssertEqual(didPresentSecond, 1)
+    XCTAssertEqual(didRunSecondReducer, 1)
+    XCTAssertEqual(didFireSecondEffect, 1)
+    XCTAssertEqual(didDismissSecond, 0)
+    XCTAssertEqual(didCancelSecondEffect, 0)
+
+    store.send(.presentFirst) {
+      $0 = .first(First.State())
+    }
+
+    XCTAssertEqual(didPresentFirst, 1)
+    XCTAssertEqual(didRunFirstReducer, 1)
+    XCTAssertEqual(didFireFirstEffect, 1)
+    XCTAssertEqual(didDismissFirst, 1)
+    XCTAssertEqual(didCancelFirstEffect, 1)
+
+    XCTAssertEqual(didPresentSecond, 1)
+    XCTAssertEqual(didRunSecondReducer, 1)
+    XCTAssertEqual(didFireSecondEffect, 1)
+    XCTAssertEqual(didDismissSecond, 1)
+    XCTAssertEqual(didCancelSecondEffect, 1)
+  }
+
+  func testPresentingWithId() {
+    var didPresentChild = [Child.State.ID]()
+    var didRunChildReducer = [Child.State.ID]()
+    var didFireChildEffect = [Child.State.ID]()
+    var didDismissChild = [Child.State.ID]()
+    var didCancelChildEffect = [Child.State.ID]()
+
+    struct Parent: ReducerProtocol {
+      struct State: Equatable {
+        var child: Child.State?
+      }
+
+      enum Action: Equatable {
+        case presentChild(id: Child.State.ID?)
+        case child(Child.Action)
+      }
+
+      func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+        switch action {
+        case .presentChild(let id):
+          state.child = id.map(Child.State.init(id:))
+          return .none
+
+        case .child:
+          return .none
+        }
+      }
+    }
+
+    struct Child: ReducerProtocol {
+      struct State: Equatable {
+        typealias ID = Int
+        var id: ID
+      }
+
+      enum Action: Equatable {
+        case performEffect
+      }
+
+      var effect: (State.ID) -> Effect<Never, Never>
+      var onReduce: (State.ID) -> Void
+
+      func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
+        onReduce(state.id)
+        switch action {
+        case .performEffect:
+          return effect(state.id)
+            .fireAndForget()
+        }
+      }
+    }
+
+    let store = TestStore(
+      initialState: Parent.State(),
+      reducer: Parent()
+        .presenting(
+          state: .keyPath(\.child),
+          id: .keyPath(\.?.id),
+          action: /Parent.Action.child,
+          onPresent: .init { _, presentedState in
+            didPresentChild.append(presentedState.id)
+            return .none
+          },
+          onDismiss: .init { _, presentedState in
+            didDismissChild.append(presentedState.id)
+            return .none
+          },
+          presented: {
+            Child(
+              effect: { id in
+                Empty(completeImmediately: false)
+                  .handleEvents(
+                    receiveSubscription: { _ in didFireChildEffect.append(id) },
+                    receiveCancel: { didCancelChildEffect.append(id) }
+                  )
+                  .eraseToEffect()
+              },
+              onReduce: {
+                didRunChildReducer.append($0)
+              }
+            )
+          }
+        )
+    )
+
+    store.send(.presentChild(id: 1)) {
+      $0.child = Child.State(id: 1)
+    }
+
+    XCTAssertEqual(didPresentChild, [1])
+    XCTAssertEqual(didRunChildReducer, [])
+    XCTAssertEqual(didFireChildEffect, [])
+    XCTAssertEqual(didDismissChild, [])
+    XCTAssertEqual(didCancelChildEffect, [])
+
+    store.send(.child(.performEffect))
+
+    XCTAssertEqual(didPresentChild, [1])
+    XCTAssertEqual(didRunChildReducer, [1])
+    XCTAssertEqual(didFireChildEffect, [1])
+    XCTAssertEqual(didDismissChild, [])
+    XCTAssertEqual(didCancelChildEffect, [])
+
+    store.send(.presentChild(id: 2)) {
+      $0.child = Child.State(id: 2)
+    }
+
+    XCTAssertEqual(didPresentChild, [1, 2])
+    XCTAssertEqual(didRunChildReducer, [1])
+    XCTAssertEqual(didFireChildEffect, [1])
+    XCTAssertEqual(didDismissChild, [1])
+    XCTAssertEqual(didCancelChildEffect, [1])
+
+    store.send(.child(.performEffect))
+
+    XCTAssertEqual(didPresentChild, [1, 2])
+    XCTAssertEqual(didRunChildReducer, [1, 2])
+    XCTAssertEqual(didFireChildEffect, [1, 2])
+    XCTAssertEqual(didDismissChild, [1])
+    XCTAssertEqual(didCancelChildEffect, [1])
+
+    store.send(.presentChild(id: nil)) {
+      $0.child = nil
+    }
+
+    XCTAssertEqual(didPresentChild, [1, 2])
+    XCTAssertEqual(didRunChildReducer, [1, 2])
+    XCTAssertEqual(didFireChildEffect, [1, 2])
+    XCTAssertEqual(didDismissChild, [1, 2])
+    XCTAssertEqual(didCancelChildEffect, [1, 2])
+  }
+}

--- a/Tests/ComposablePresentationTests/PresentingReducerTests.swift
+++ b/Tests/ComposablePresentationTests/PresentingReducerTests.swift
@@ -203,7 +203,7 @@ final class PresentingReducerTests: XCTestCase {
       var onReduce: () -> Void
 
       func reduce(into state: inout State, action: Action) -> Effect<Action, Never> {
-        onReduce() // didRunSecondReducer += 1
+        onReduce()
         switch action {
         case .performEffect:
           return effect()


### PR DESCRIPTION
## Summary

This PR adopts `ReducerProtocol`.

More details: 

- https://github.com/pointfreeco/swift-composable-architecture/discussions/1282
- https://github.com/pointfreeco/swift-composable-architecture/pull/1283

## What was done

- [x] Switch to [protocol-beta](https://github.com/pointfreeco/swift-composable-architecture/tree/protocol-beta) branch of Composable Architecture.
- [x] Add `ReducerProtocol` version of `Reducer+Presenting` extension.
- [x] Add `ReducerProtocol` version of `Reducer+PresentingForEach` extension.
- [x] Soft-deprecate legacy `Reducer` extensions.
- [x] Add documentation for `ReducerProtocol` extensions.
- [x] Switch to a stable release of Composable Architecture when available.

## Review notes

~~⚠️  This is a draft PR with a beta release of the Composable Presentation library. Not suitable for production.~~
