### PR TITLE
Add presentation ID

### DIFF
--- a/Sources/ComposablePresentation/PresentingForEachReducer.swift
+++ b/Sources/ComposablePresentation/PresentingForEachReducer.swift
@@ -18,7 +18,7 @@ extension ReducerProtocol {
   /// - Returns: Combined reducer.
   @inlinable
   public func presentingForEach<ID: Hashable, Element: ReducerProtocol>(
-    presentationID: UUID = UUID(),
+    presentationID: AnyHashable = UUID(),
     state toElementState: WritableKeyPath<State, IdentifiedArray<ID, Element.State>>,
     action toElementAction: CasePath<Action, (ID, Element.Action)>,
     onPresent: PresentingForEachReducerAction<ID, State, Action> = .empty,
@@ -49,7 +49,7 @@ public struct _PresentingForEachReducer<
   Element: ReducerProtocol
 >: ReducerProtocol {
   @usableFromInline
-  let presentationID: UUID
+  let presentationID: AnyHashable
 
   @usableFromInline
   let parent: Parent
@@ -80,7 +80,7 @@ public struct _PresentingForEachReducer<
 
   @inlinable
   init(
-    presentationID: UUID,
+    presentationID: AnyHashable,
     parent: Parent,
     toElementState: WritableKeyPath<Parent.State, IdentifiedArray<ID, Element.State>>,
     toElementAction: CasePath<Parent.Action, (ID, Element.Action)>,
@@ -177,13 +177,13 @@ public struct PresentingForEachReducerAction<ID, State, Action> {
 /// Effect produced by element reducer within `.presentingForEach` higher order reducer.
 public struct PresentingForEachReducerEffectID: Hashable {
   @usableFromInline
-  let presentationID: UUID
+  let presentationID: AnyHashable
 
   @usableFromInline
   let elementID: AnyHashable
 
   @inlinable
-  init(presentationID: UUID, elementID: AnyHashable) {
+  init(presentationID: AnyHashable, elementID: AnyHashable) {
     self.presentationID = presentationID
     self.elementID = elementID
   }

--- a/Sources/ComposablePresentation/PresentingForEachReducer.swift
+++ b/Sources/ComposablePresentation/PresentingForEachReducer.swift
@@ -9,7 +9,7 @@ extension ReducerProtocol {
   /// - Inspired by [Reducer.presents function](https://github.com/pointfreeco/swift-composable-architecture/blob/9ec4b71e5a84f448dedb063a21673e4696ce135f/Sources/ComposableArchitecture/Reducer.swift#L549-L572) from `iso` branch of `swift-composable-architecture` repository.
   ///
   /// - Parameters:
-  ///   - reducerID: Unique identifier for the presentation. Defaults to new UUID.
+  ///   - presentationID: Unique identifier for the presentation. Defaults to new UUID.
   ///   - state: A key path form parent state to identified array that hold element states.
   ///   - action: A case path that can extract/embed element action from parent.
   ///   - onPresent: An action run when element is added to identified array. Defaults to empty action.
@@ -18,7 +18,7 @@ extension ReducerProtocol {
   /// - Returns: Combined reducer.
   @inlinable
   public func presentingForEach<ID: Hashable, Element: ReducerProtocol>(
-    reducerID: UUID = UUID(),
+    presentationID: UUID = UUID(),
     state toElementState: WritableKeyPath<State, IdentifiedArray<ID, Element.State>>,
     action toElementAction: CasePath<Action, (ID, Element.Action)>,
     onPresent: PresentingForEachReducerAction<ID, State, Action> = .empty,
@@ -29,7 +29,7 @@ extension ReducerProtocol {
     line: UInt = #line
   ) -> _PresentingForEachReducer<Self, ID, Element> {
     .init(
-      reducerID: reducerID,
+      presentationID: presentationID,
       parent: self,
       toElementState: toElementState,
       toElementAction: toElementAction,
@@ -49,7 +49,7 @@ public struct _PresentingForEachReducer<
   Element: ReducerProtocol
 >: ReducerProtocol {
   @usableFromInline
-  let reducerID: UUID
+  let presentationID: UUID
 
   @usableFromInline
   let parent: Parent
@@ -80,7 +80,7 @@ public struct _PresentingForEachReducer<
 
   @inlinable
   init(
-    reducerID: UUID,
+    presentationID: UUID,
     parent: Parent,
     toElementState: WritableKeyPath<Parent.State, IdentifiedArray<ID, Element.State>>,
     toElementAction: CasePath<Parent.Action, (ID, Element.Action)>,
@@ -91,7 +91,7 @@ public struct _PresentingForEachReducer<
     fileID: StaticString = #fileID,
     line: UInt = #line
   ) {
-    self.reducerID = reducerID
+    self.presentationID = presentationID
     self.parent = parent
     self.toElementState = toElementState
     self.toElementAction = toElementAction
@@ -115,7 +115,7 @@ public struct _PresentingForEachReducer<
     }
 
     func effectID(for id: ID) -> PresentingForEachReducerEffectID {
-      .init(reducerID: reducerID, elementID: id)
+      .init(presentationID: presentationID, elementID: id)
     }
 
     let oldIds = state[keyPath: toElementState].ids
@@ -177,14 +177,14 @@ public struct PresentingForEachReducerAction<ID, State, Action> {
 /// Effect produced by element reducer within `.presentingForEach` higher order reducer.
 public struct PresentingForEachReducerEffectID: Hashable {
   @usableFromInline
-  let reducerID: UUID
+  let presentationID: UUID
 
   @usableFromInline
   let elementID: AnyHashable
 
   @inlinable
-  init(reducerID: UUID, elementID: AnyHashable) {
-    self.reducerID = reducerID
+  init(presentationID: UUID, elementID: AnyHashable) {
+    self.presentationID = presentationID
     self.elementID = elementID
   }
 }

--- a/Sources/ComposablePresentation/PresentingForEachReducer.swift
+++ b/Sources/ComposablePresentation/PresentingForEachReducer.swift
@@ -9,6 +9,7 @@ extension ReducerProtocol {
   /// - Inspired by [Reducer.presents function](https://github.com/pointfreeco/swift-composable-architecture/blob/9ec4b71e5a84f448dedb063a21673e4696ce135f/Sources/ComposableArchitecture/Reducer.swift#L549-L572) from `iso` branch of `swift-composable-architecture` repository.
   ///
   /// - Parameters:
+  ///   - reducerID: Unique identifier for the presentation. Defaults to new UUID.
   ///   - state: A key path form parent state to identified array that hold element states.
   ///   - action: A case path that can extract/embed element action from parent.
   ///   - onPresent: An action run when element is added to identified array. Defaults to empty action.
@@ -17,6 +18,7 @@ extension ReducerProtocol {
   /// - Returns: Combined reducer.
   @inlinable
   public func presentingForEach<ID: Hashable, Element: ReducerProtocol>(
+    reducerID: UUID = UUID(),
     state toElementState: WritableKeyPath<State, IdentifiedArray<ID, Element.State>>,
     action toElementAction: CasePath<Action, (ID, Element.Action)>,
     onPresent: PresentingForEachReducerAction<ID, State, Action> = .empty,
@@ -27,7 +29,7 @@ extension ReducerProtocol {
     line: UInt = #line
   ) -> _PresentingForEachReducer<Self, ID, Element> {
     .init(
-      reducerID: UUID(),
+      reducerID: reducerID,
       parent: self,
       toElementState: toElementState,
       toElementAction: toElementAction,

--- a/Sources/ComposablePresentation/PresentingReducer.swift
+++ b/Sources/ComposablePresentation/PresentingReducer.swift
@@ -17,7 +17,7 @@ extension ReducerProtocol {
   /// - Returns: Combined reducer.
   @inlinable
   public func presenting<ID: Hashable, Presented: ReducerProtocol>(
-    presentationID: UUID = UUID(),
+    presentationID: AnyHashable = UUID(),
     state toPresentedState: PresentingReducerToPresentedState<State, Presented.State>,
     id toPresentedID: PresentingReducerToPresentedID<Presented.State, ID>,
     action toPresentedAction: CasePath<Action, Presented.Action>,
@@ -50,7 +50,7 @@ public struct _PresentingReducer<
   Presented: ReducerProtocol
 >: ReducerProtocol {
   @usableFromInline
-  let presentationID: UUID
+  let presentationID: AnyHashable
 
   @usableFromInline
   let parent: Parent
@@ -84,7 +84,7 @@ public struct _PresentingReducer<
 
   @inlinable
   init(
-    presentationID: UUID,
+    presentationID: AnyHashable,
     parent: Parent,
     presented: Presented,
     toPresentedState: PresentingReducerToPresentedState<Parent.State, Presented.State>,
@@ -257,13 +257,13 @@ public struct PresentingReducerAction<State, PresentedState, Action> {
 /// Effect produced by presented reducer within `.presenting` higher order reducer.
 public struct PresentingReducerEffectId<PresentedID: Hashable>: Hashable {
   @usableFromInline
-  let presentationID: UUID
+  let presentationID: AnyHashable
 
   @usableFromInline
   let presentedID: PresentedID
 
   @inlinable
-  init(presentationID: UUID, presentedID: PresentedID) {
+  init(presentationID: AnyHashable, presentedID: PresentedID) {
     self.presentationID = presentationID
     self.presentedID = presentedID
   }

--- a/Sources/ComposablePresentation/PresentingReducer.swift
+++ b/Sources/ComposablePresentation/PresentingReducer.swift
@@ -7,6 +7,7 @@ extension ReducerProtocol {
   /// - All effects returned by the presented reducer are cancelled when presented `ID` changes.
   ///
   /// - Parameters:
+  ///   - reducerID: Unique identifier for the presentation. Defaults to new UUID.
   ///   - state: `PresentingReducerToPresentedState` that can get/set presented state in parent.
   ///   - id: `PresentingReducerToPresentedID` that returns `ID` for given presented state.
   ///   - action: A case path that can extract/embed presented action from parent.
@@ -16,6 +17,7 @@ extension ReducerProtocol {
   /// - Returns: Combined reducer.
   @inlinable
   public func presenting<ID: Hashable, Presented: ReducerProtocol>(
+    reducerID: UUID = UUID(),
     state toPresentedState: PresentingReducerToPresentedState<State, Presented.State>,
     id toPresentedID: PresentingReducerToPresentedID<Presented.State, ID>,
     action toPresentedAction: CasePath<Action, Presented.Action>,
@@ -27,7 +29,7 @@ extension ReducerProtocol {
     line: UInt = #line
   ) -> _PresentingReducer<Self, ID, Presented> {
     .init(
-      reducerID: UUID(),
+      reducerID: reducerID,
       parent: self,
       presented: presented(),
       toPresentedState: toPresentedState,

--- a/Sources/ComposablePresentation/PresentingReducer.swift
+++ b/Sources/ComposablePresentation/PresentingReducer.swift
@@ -7,7 +7,7 @@ extension ReducerProtocol {
   /// - All effects returned by the presented reducer are cancelled when presented `ID` changes.
   ///
   /// - Parameters:
-  ///   - reducerID: Unique identifier for the presentation. Defaults to new UUID.
+  ///   - presentationID: Unique identifier for the presentation. Defaults to new UUID.
   ///   - state: `PresentingReducerToPresentedState` that can get/set presented state in parent.
   ///   - id: `PresentingReducerToPresentedID` that returns `ID` for given presented state.
   ///   - action: A case path that can extract/embed presented action from parent.
@@ -17,7 +17,7 @@ extension ReducerProtocol {
   /// - Returns: Combined reducer.
   @inlinable
   public func presenting<ID: Hashable, Presented: ReducerProtocol>(
-    reducerID: UUID = UUID(),
+    presentationID: UUID = UUID(),
     state toPresentedState: PresentingReducerToPresentedState<State, Presented.State>,
     id toPresentedID: PresentingReducerToPresentedID<Presented.State, ID>,
     action toPresentedAction: CasePath<Action, Presented.Action>,
@@ -29,7 +29,7 @@ extension ReducerProtocol {
     line: UInt = #line
   ) -> _PresentingReducer<Self, ID, Presented> {
     .init(
-      reducerID: reducerID,
+      presentationID: presentationID,
       parent: self,
       presented: presented(),
       toPresentedState: toPresentedState,
@@ -50,7 +50,7 @@ public struct _PresentingReducer<
   Presented: ReducerProtocol
 >: ReducerProtocol {
   @usableFromInline
-  let reducerID: UUID
+  let presentationID: UUID
 
   @usableFromInline
   let parent: Parent
@@ -84,7 +84,7 @@ public struct _PresentingReducer<
 
   @inlinable
   init(
-    reducerID: UUID,
+    presentationID: UUID,
     parent: Parent,
     presented: Presented,
     toPresentedState: PresentingReducerToPresentedState<Parent.State, Presented.State>,
@@ -96,7 +96,7 @@ public struct _PresentingReducer<
     fileID: StaticString,
     line: UInt
   ) {
-    self.reducerID = reducerID
+    self.presentationID = presentationID
     self.parent = parent
     self.presented = presented
     self.toPresentedState = toPresentedState
@@ -119,7 +119,7 @@ public struct _PresentingReducer<
     let oldPresentedID = toPresentedID(oldPresentedState)
 
     let presentedEffectsID = PresentingReducerEffectId(
-      reducerID: reducerID,
+      presentationID: presentationID,
       presentedID: oldPresentedID
     )
     let shouldRunPresented = toPresentedAction.extract(from: action) != nil
@@ -257,14 +257,14 @@ public struct PresentingReducerAction<State, PresentedState, Action> {
 /// Effect produced by presented reducer within `.presenting` higher order reducer.
 public struct PresentingReducerEffectId<PresentedID: Hashable>: Hashable {
   @usableFromInline
-  let reducerID: UUID
+  let presentationID: UUID
 
   @usableFromInline
   let presentedID: PresentedID
 
   @inlinable
-  init(reducerID: UUID, presentedID: PresentedID) {
-    self.reducerID = reducerID
+  init(presentationID: UUID, presentedID: PresentedID) {
+    self.presentationID = presentationID
     self.presentedID = presentedID
   }
 }

--- a/Sources/ComposablePresentation/Reducer+Presenting.swift
+++ b/Sources/ComposablePresentation/Reducer+Presenting.swift
@@ -7,6 +7,7 @@ extension Reducer {
   /// - All effects returned by the local reducer are cancelled when `LocalID` changes.
   ///
   /// - Parameters:
+  ///   - presentationID: Unique identifier for the presentation. Defaults to new UUID.
   ///   - localReducer: A reducer that works on `LocalState`, `LocalAction`, `LocalEnvironment`.
   ///   - toLocalState: `ReducerPresentingToLocalState` that can get/set `LocalState` inside `State`.
   ///   - toLocalID: `ReducerPresentingToLocalId` that returns `LocalID` for given `LocalState?`.
@@ -26,6 +27,7 @@ extension Reducer {
     message: "This API has been soft-deprecated in favor of `ReducerProtocol.presenting`."
   )
   public func presenting<LocalState, LocalID: Hashable, LocalAction, LocalEnvironment>(
+    presentationID: AnyHashable = UUID(),
     _ localReducer: Reducer<LocalState, LocalAction, LocalEnvironment>,
     state toLocalState: ReducerPresentingToLocalState<State, LocalState>,
     id toLocalId: ReducerPresentingToLocalId<LocalState, LocalID>,
@@ -37,8 +39,7 @@ extension Reducer {
     fileID: StaticString = #fileID,
     line: UInt = #line
   ) -> Self {
-    let presentationID = UUID()
-    return Reducer { state, action, env in
+    Reducer { state, action, env in
       _PresentingReducer(
         presentationID: presentationID,
         parent: Reduce(AnyReducer(self.run), environment: env),

--- a/Sources/ComposablePresentation/Reducer+Presenting.swift
+++ b/Sources/ComposablePresentation/Reducer+Presenting.swift
@@ -37,10 +37,10 @@ extension Reducer {
     fileID: StaticString = #fileID,
     line: UInt = #line
   ) -> Self {
-    let reducerId = UUID()
+    let presentationID = UUID()
     return Reducer { state, action, env in
       _PresentingReducer(
-        reducerID: reducerId,
+        presentationID: presentationID,
         parent: Reduce(AnyReducer(self.run), environment: env),
         presented: Reduce { state, action in
           localReducer.run(&state, action, toLocalEnvironment(env))

--- a/Sources/ComposablePresentation/Reducer+PresentingForEach.swift
+++ b/Sources/ComposablePresentation/Reducer+PresentingForEach.swift
@@ -37,10 +37,10 @@ extension Reducer {
     fileID: StaticString = #fileID,
     line: UInt = #line
   ) -> Self {
-    let reducerId = UUID()
+    let presentationID = UUID()
     return Reducer { state, action, env in
       _PresentingForEachReducer(
-        reducerID: reducerId,
+        presentationID: presentationID,
         parent: Reduce(AnyReducer(self.run), environment: env),
         toElementState: toLocalState,
         toElementAction: toLocalAction,

--- a/Sources/ComposablePresentation/Reducer+PresentingForEach.swift
+++ b/Sources/ComposablePresentation/Reducer+PresentingForEach.swift
@@ -9,6 +9,7 @@ extension Reducer {
   /// - Inspired by [Reducer.presents function](https://github.com/pointfreeco/swift-composable-architecture/blob/9ec4b71e5a84f448dedb063a21673e4696ce135f/Sources/ComposableArchitecture/Reducer.swift#L549-L572) from `iso` branch of `swift-composable-architecture` repository.
   ///
   /// - Parameters:
+  ///   - presentationID: Unique identifier for the presentation. Defaults to new UUID.
   ///   - localReducer: A reducer that works on `LocalState`, `LocalAction`, `LocalEnvironment`.
   ///   - toLocalState: A key path from `State` to `IdentifiedArrayOf<LocalState>`.
   ///   - toLocalAction: A case path that can extract/embed `LocalAction` from `Action`.
@@ -27,6 +28,7 @@ extension Reducer {
     message: "This API has been soft-deprecated in favor of `ReducerProtocol.presentingForEach`."
   )
   public func presenting<LocalState, LocalAction, LocalEnvironment>(
+    presentationID: AnyHashable = UUID(),
     forEach localReducer: Reducer<LocalState, LocalAction, LocalEnvironment>,
     state toLocalState: WritableKeyPath<State, IdentifiedArrayOf<LocalState>>,
     action toLocalAction: CasePath<Action, (LocalState.ID, LocalAction)>,
@@ -37,8 +39,7 @@ extension Reducer {
     fileID: StaticString = #fileID,
     line: UInt = #line
   ) -> Self {
-    let presentationID = UUID()
-    return Reducer { state, action, env in
+    Reducer { state, action, env in
       _PresentingForEachReducer(
         presentationID: presentationID,
         parent: Reduce(AnyReducer(self.run), environment: env),


### PR DESCRIPTION
## Summary

This PR adds `presentationID` parameter `Reducer` and `ReducerProtocol` methods. The `presentationID` identifies the presentation and is used to cancel effects on dismission.

## What was done

- [x] Add `presentationID` parameter to `ReducerProtocol.presenting` method.
- [x] Add `presentationID` parameter to `ReducerProtocol.presentingForEach` method.
- [x] Add `presentationID` parameter to legacy `Reducer.presenting` method.
- [x] Add `presentationID` parameter to legacy `Reducer.presentingForEach` method.

## Review notes

The `presentationID` parameter defaults to a new `UUID` and can be customized to `AnyHashable` value that should uniquely identify the presenting reducer. If this requirement is not met, the effects might not be canceled on dismission, which could lead to unexpected behavior.