### PR TITLE
Add PresentingCaseReducer

### DIFF
--- a/ComposablePresentation.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ComposablePresentation.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/combine-schedulers",
       "state" : {
-        "revision" : "aa3e575929f2bcc5bad012bd2575eae716cbcdf7",
-        "version" : "0.8.0"
+        "revision" : "882ac01eb7ef9e36d4467eb4b1151e74fcef85ab",
+        "version" : "0.9.1"
       }
     },
     {
@@ -14,8 +14,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-case-paths",
       "state" : {
-        "revision" : "15bba50ebf3a2065388c8d12210debe4f6ada202",
-        "version" : "0.10.0"
+        "revision" : "bb436421f57269fbcfe7360735985321585a86e5",
+        "version" : "0.10.1"
+      }
+    },
+    {
+      "identity" : "swift-clocks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-clocks",
+      "state" : {
+        "revision" : "20b25ca0dd88ebfb9111ec937814ddc5a8880172",
+        "version" : "0.2.0"
       }
     },
     {
@@ -23,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections",
       "state" : {
-        "revision" : "f504716c27d2e5d4144fa4794b12129301d17729",
-        "version" : "1.0.3"
+        "revision" : "937e904258d22af6e447a0b72c0bc67583ef64a2",
+        "version" : "1.0.4"
       }
     },
     {
@@ -32,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-composable-architecture.git",
       "state" : {
-        "revision" : "5c476994eaa79af8e466041f6de1ab116f37c528",
-        "version" : "0.42.0"
+        "revision" : "c9259b5f74892690cb04a9a8088b4a1789b05a7d",
+        "version" : "0.47.2"
       }
     },
     {
@@ -41,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "819d9d370cd721c9d87671e29d947279292e4541",
-        "version" : "0.6.0"
+        "revision" : "ead7d30cc224c3642c150b546f4f1080d1c411a8",
+        "version" : "0.6.1"
       }
     },
     {
@@ -50,8 +59,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-identified-collections",
       "state" : {
-        "revision" : "bfb0d43e75a15b6dfac770bf33479e8393884a36",
-        "version" : "0.4.1"
+        "revision" : "a08887de589e3829d488e0b4b707b2ca804b1060",
+        "version" : "0.5.0"
+      }
+    },
+    {
+      "identity" : "swiftui-navigation",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swiftui-navigation",
+      "state" : {
+        "revision" : "46acf5ecc1cabdb28d7fe03289f6c8b13a023f52",
+        "version" : "0.4.5"
       }
     },
     {
@@ -59,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "30314f1ece684dd60679d598a9b89107557b67d9",
-        "version" : "0.4.1"
+        "revision" : "5a5457a744239896e9b0b03a8e1a5069c3e7b91f",
+        "version" : "0.6.0"
       }
     }
   ],

--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		3154EC1526DFD1F500D69F22 /* ComposablePresentation in Frameworks */ = {isa = PBXBuildFile; productRef = 3154EC1426DFD1F500D69F22 /* ComposablePresentation */; };
 		3154EC1726DFD41700D69F22 /* App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3154EC1626DFD41700D69F22 /* App.swift */; };
 		3156F63F274253D700CA965F /* SwitchStoreExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3156F63E274253D700CA965F /* SwitchStoreExample.swift */; };
+		31817E682950A982000BC1C3 /* DestinationExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31817E672950A982000BC1C3 /* DestinationExample.swift */; };
 		3195775C27415EF100FFA9EB /* PopToRootExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3195775B27415EF100FFA9EB /* PopToRootExample.swift */; };
 		31D7D9B42740907F001699F4 /* NavigationLinkExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31D7D9B32740907F001699F4 /* NavigationLinkExample.swift */; };
 		31D7D9B62740909C001699F4 /* TimerFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31D7D9B52740909C001699F4 /* TimerFeature.swift */; };
@@ -26,6 +27,7 @@
 		3154EC0D26DFD01800D69F22 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		3154EC1626DFD41700D69F22 /* App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App.swift; sourceTree = "<group>"; };
 		3156F63E274253D700CA965F /* SwitchStoreExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchStoreExample.swift; sourceTree = "<group>"; };
+		31817E672950A982000BC1C3 /* DestinationExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DestinationExample.swift; sourceTree = "<group>"; };
 		3195775B27415EF100FFA9EB /* PopToRootExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopToRootExample.swift; sourceTree = "<group>"; };
 		31D7D9B32740907F001699F4 /* NavigationLinkExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationLinkExample.swift; sourceTree = "<group>"; };
 		31D7D9B52740909C001699F4 /* TimerFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerFeature.swift; sourceTree = "<group>"; };
@@ -74,6 +76,7 @@
 				31D7D9B9274096B6001699F4 /* ForEachStoreExample.swift */,
 				3195775B27415EF100FFA9EB /* PopToRootExample.swift */,
 				3156F63E274253D700CA965F /* SwitchStoreExample.swift */,
+				31817E672950A982000BC1C3 /* DestinationExample.swift */,
 				31D7D9B52740909C001699F4 /* TimerFeature.swift */,
 				3154EC0826DFD01800D69F22 /* Assets.xcassets */,
 				3154EC0D26DFD01800D69F22 /* Info.plist */,
@@ -159,6 +162,7 @@
 				31D7D9BC274099F2001699F4 /* SheetExample.swift in Sources */,
 				3156F63F274253D700CA965F /* SwitchStoreExample.swift in Sources */,
 				31D7D9BA274096B6001699F4 /* ForEachStoreExample.swift in Sources */,
+				31817E682950A982000BC1C3 /* DestinationExample.swift in Sources */,
 				31F8124327C5A2F400AFC10A /* NavigationLinkSelectionExample.swift in Sources */,
 				3154EC1726DFD41700D69F22 /* App.swift in Sources */,
 			);

--- a/Example/Example/App.swift
+++ b/Example/Example/App.swift
@@ -18,6 +18,7 @@ struct AppView: View {
     case forEachStoreExample
     case popToRootExample
     case switchStoreExample
+    case destinationExample
 
     var title: String {
       rawValue[rawValue.startIndex].uppercased() +
@@ -52,6 +53,9 @@ struct AppView: View {
 
           case .switchStoreExample:
             SwitchStoreExample()
+
+          case .destinationExample:
+            DestinationExample()
           }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Example/Example/DestinationExample.swift
+++ b/Example/Example/DestinationExample.swift
@@ -1,0 +1,251 @@
+import ComposableArchitecture
+import ComposablePresentation
+import SwiftUI
+
+struct DestinationExample: View {
+  // MARK: - Reducers
+
+  struct Main: ReducerProtocol {
+    struct State {
+      enum Destination {
+        case first(First.State)
+        case second(Second.State)
+        case alert(AlertState<Action.Alert>)
+      }
+
+      var destination: Destination?
+    }
+
+    enum Action {
+      enum Alert {
+        case firstTapped
+        case secondTapped
+        case dismissed
+      }
+
+      case firstButtonTapped
+      case secondButtonTapped
+      case alertButtonTapped
+      case didDismissFirst
+      case didDismissSecond
+      case first(First.Action)
+      case second(Second.Action)
+      case alert(Main.Action.Alert)
+    }
+
+    enum Presentation: Hashable {
+      case first
+      case second
+    }
+
+    var body: some ReducerProtocol<State, Action> {
+      Reduce { state, action in
+        switch action {
+        case .firstButtonTapped, .alert(.firstTapped):
+          state.destination = .first(First.State())
+          return .none
+
+        case .secondButtonTapped, .alert(.secondTapped):
+          state.destination = .second(Second.State())
+          return .none
+
+        case .alertButtonTapped:
+          if #available(iOS 15.0, *) {
+            state.destination = .alert(AlertState(
+              title: { TextState("Title") },
+              actions: {
+                let actions: [ButtonState<Action.Alert>] = [
+                  ButtonState(action: .firstTapped) {
+                    TextState("Present first")
+                  },
+                  ButtonState(action: .secondTapped) {
+                    TextState("Present second")
+                  },
+                  ButtonState.cancel(TextState("Cancel"))
+                ]
+                return actions
+              },
+              message: { TextState("Message") }
+            ))
+          }
+          return .none
+
+        case .didDismissFirst:
+          if (/State.Destination.first).extract(from: state.destination) != nil {
+            state.destination = nil
+          }
+          return .none
+
+        case .didDismissSecond:
+          if (/State.Destination.second).extract(from: state.destination) != nil {
+            state.destination = nil
+          }
+          return .none
+
+        case .alert(.dismissed):
+          if (/State.Destination.alert).extract(from: state.destination) != nil {
+            state.destination = nil
+          }
+          return .none
+
+        case .first, .second:
+          return .none
+        }
+      }
+      .presenting(
+        presentationID: Presentation.first,
+        unwrapping: \.destination,
+        case: /State.Destination.first,
+        id: .notNil(),
+        action: /Action.first,
+        presented: { First() }
+      )
+      .presenting(
+        presentationID: Presentation.second,
+        unwrapping: \.destination,
+        case: /State.Destination.second,
+        id: .notNil(),
+        action: /Action.second,
+        presented: { Second() }
+      )
+    }
+  }
+
+  struct First: ReducerProtocol {
+    struct State {
+      var timer = TimerState()
+    }
+
+    enum Action {
+      case timer(TimerAction)
+    }
+
+    var body: some ReducerProtocol<State, Action> {
+      Scope(state: \.timer, action: /Action.timer) {
+        Reduce(timerReducer, environment: ())
+      }
+    }
+  }
+
+  struct Second: ReducerProtocol {
+    struct State {
+      var timer = TimerState()
+    }
+
+    enum Action {
+      case timer(TimerAction)
+    }
+
+    var body: some ReducerProtocol<State, Action> {
+      Scope(state: \.timer, action: /Action.timer) {
+        Reduce(timerReducer, environment: ())
+      }
+    }
+  }
+
+  // MARK: - Views
+
+  struct MainView: View {
+    let store: StoreOf<Main>
+
+    var body: some View {
+      WithViewStore(store.stateless) { viewStore in
+        NavigationView {
+          VStack(alignment: .leading, spacing: 0) {
+            Button {
+              viewStore.send(.firstButtonTapped)
+            } label: {
+              Text("→ First (sheet)")
+                .padding()
+            }
+
+            Button {
+              viewStore.send(.secondButtonTapped)
+            } label: {
+              Text("→ Second (navigation link)")
+                .padding()
+            }
+
+            Button {
+              viewStore.send(.alertButtonTapped)
+            } label: {
+              Text("→ Alert")
+                .padding()
+            }
+          }
+          .padding()
+          .sheet(
+            store.scope(
+              state: { (/Main.State.Destination.first).extract(from: $0.destination) },
+              action: Main.Action.first
+            ),
+            onDismiss: { viewStore.send(.didDismissFirst) },
+            content: FirstView.init(store:)
+          )
+          .background(
+            NavigationLinkWithStore(
+              store.scope(
+                state: { (/Main.State.Destination.second).extract(from: $0.destination) },
+                action: Main.Action.second
+              ),
+              onDeactivate: { viewStore.send(.didDismissSecond) },
+              destination: SecondView.init(store:)
+            )
+          )
+          .alert(
+            store.scope(
+              state: { (/Main.State.Destination.alert).extract(from: $0.destination) },
+              action: Main.Action.alert
+            ),
+            dismiss: .dismissed
+          )
+        }
+      }
+    }
+  }
+
+  struct FirstView: View {
+    let store: StoreOf<First>
+
+    var body: some View {
+      VStack {
+        Text("First").font(.title)
+
+        TimerView(store: store.scope(
+          state: \.timer,
+          action: First.Action.timer
+        ))
+      }
+      .padding()
+    }
+  }
+
+  struct SecondView: View {
+    let store: StoreOf<Second>
+
+    var body: some View {
+      VStack {
+        Text("Second").font(.title)
+
+        TimerView(store: store.scope(
+          state: \.timer,
+          action: Second.Action.timer
+        ))
+      }
+      .padding()
+    }
+  }
+
+  var body: some View {
+    MainView(store: Store(
+      initialState: Main.State(),
+      reducer: Main()._printChanges()
+    ))
+  }
+}
+
+struct DestinationExample_Previews: PreviewProvider {
+  static var previews: some View {
+    DestinationExample()
+  }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
   dependencies: [
     .package(
       url: "https://github.com/pointfreeco/swift-composable-architecture.git",
-      .upToNextMajor(from: "0.42.0")
+      .upToNextMajor(from: "0.47.2")
     ),
   ],
   targets: [

--- a/Sources/ComposablePresentation/PresentingCaseReducer.swift
+++ b/Sources/ComposablePresentation/PresentingCaseReducer.swift
@@ -1,0 +1,236 @@
+import ComposableArchitecture
+import Foundation
+
+extension ReducerProtocol {
+  @inlinable
+  // TODO: documentation
+  public func presenting<ID: Hashable, Enum, Presented: ReducerProtocol>(
+    presentationID: AnyHashable = UUID(),
+    unwrapping toEnum: WritableKeyPath<State, Enum?>,
+    case toCase: CasePath<Enum, Presented.State>,
+    id toPresentedID: _PresentingCaseReducer<Self, Enum, ID, Presented>.ToPresentedID,
+    action toPresentedAction: CasePath<Action, Presented.Action>,
+    onPresent: _PresentingCaseReducer<Self, Enum, ID, Presented>.ActionHandler = .empty,
+    onDismiss: _PresentingCaseReducer<Self, Enum, ID, Presented>.ActionHandler = .empty,
+    @ReducerBuilderOf<Presented> presented: () -> Presented,
+    file: StaticString = #file,
+    fileID: StaticString = #fileID,
+    line: UInt = #line
+  ) -> _PresentingCaseReducer<Self, Enum, ID, Presented> {
+    .init(
+      presentationID: presentationID,
+      parent: self,
+      presented: presented(),
+      toEnum: toEnum,
+      toCase: toCase,
+      toPresentedID: toPresentedID,
+      toPresentedAction: toPresentedAction,
+      onPresent: onPresent,
+      onDismiss: onDismiss,
+      file: file,
+      fileID: fileID,
+      line: line
+    )
+  }
+}
+
+public struct _PresentingCaseReducer<
+  Parent: ReducerProtocol,
+  Enum,
+  ID: Hashable,
+  Presented: ReducerProtocol
+>: ReducerProtocol {
+  @usableFromInline
+  let presentationID: AnyHashable
+
+  @usableFromInline
+  let parent: Parent
+
+  @usableFromInline
+  let presented: Presented
+
+  @usableFromInline
+  let toEnum: WritableKeyPath<Parent.State, Enum?>
+
+  @usableFromInline
+  let toCase: CasePath<Enum, Presented.State>
+
+  @usableFromInline
+  let toPresentedID: ToPresentedID
+
+  @usableFromInline
+  let toPresentedAction: CasePath<Parent.Action, Presented.Action>
+
+  @usableFromInline
+  let onPresent: ActionHandler
+
+  @usableFromInline
+  let onDismiss: ActionHandler
+
+  @usableFromInline
+  let file: StaticString
+
+  @usableFromInline
+  let fileID: StaticString
+
+  @usableFromInline
+  let line: UInt
+
+  @inlinable
+  init(
+    presentationID: AnyHashable,
+    parent: Parent,
+    presented: Presented,
+    toEnum: WritableKeyPath<State, Enum?>,
+    toCase: CasePath<Enum, Presented.State>,
+    toPresentedID: ToPresentedID,
+    toPresentedAction: CasePath<Parent.Action, Presented.Action>,
+    onPresent: ActionHandler,
+    onDismiss: ActionHandler,
+    file: StaticString,
+    fileID: StaticString,
+    line: UInt
+  ) {
+    self.presentationID = presentationID
+    self.parent = parent
+    self.presented = presented
+    self.toEnum = toEnum
+    self.toCase = toCase
+    self.toPresentedID = toPresentedID
+    self.toPresentedAction = toPresentedAction
+    self.onPresent = onPresent
+    self.onDismiss = onDismiss
+    self.file = file
+    self.fileID = fileID
+    self.line = line
+  }
+
+  @inlinable
+  public func reduce(
+    into state: inout Parent.State,
+    action: Parent.Action
+  ) -> Effect<Parent.Action, Never> {
+    func toPresentedState(_ state: Parent.State) -> Presented.State? {
+      guard let `enum` = state[keyPath: toEnum] else { return nil }
+      return toCase.extract(from: `enum`)
+    }
+
+    let oldState = state
+    let oldPresentedState = toPresentedState(oldState)
+    let oldPresentedID = toPresentedID(oldPresentedState)
+
+    let presentedEffectsID = PresentingReducerEffectId(
+      presentationID: presentationID,
+      presentedID: oldPresentedID
+    )
+    let shouldRunPresented = toPresentedAction.extract(from: action) != nil
+    let presentedEffects: Effect<Action, Never>
+    if shouldRunPresented {
+      presentedEffects = EmptyReducer()
+        .ifLet(
+          toEnum,
+          action: toPresentedAction,
+          then: {
+            EmptyReducer()
+              .ifCaseLet(
+                toCase,
+                action: /.self,
+                then: { presented },
+                file: file,
+                fileID: fileID,
+                line: line
+              )
+          },
+          file: file,
+          fileID: fileID,
+          line: line
+        )
+        .reduce(into: &state, action: action)
+        .cancellable(id: presentedEffectsID)
+    } else {
+      presentedEffects = .none
+    }
+
+    let effects = parent.reduce(into: &state, action: action)
+    let newState = state
+    let newPresentedState = toPresentedState(newState)
+    let newPresentedID = toPresentedID(newPresentedState)
+
+    var presentationEffects: [Effect<Action, Never>] = []
+    if oldPresentedID != newPresentedID {
+      if let oldPresentedState = oldPresentedState {
+        presentationEffects.append(onDismiss(&state, oldPresentedState))
+        presentationEffects.append(.cancel(id: presentedEffectsID))
+      }
+      if let newPresentedState = newPresentedState {
+        presentationEffects.append(onPresent(&state, newPresentedState))
+      }
+    }
+
+    return .merge(
+      presentedEffects,
+      effects,
+      .merge(presentationEffects)
+    )
+  }
+}
+
+extension _PresentingCaseReducer {
+  /// `Presented.State?` → `ID` transformation
+  public struct ToPresentedID {
+    public typealias Run = (Presented.State?) -> ID
+
+    /// Identifies `Presented.State?` by just checking if it's not `nil`.
+    ///
+    /// - Use this with caution, as it only checks if the `State` is `nil`.
+    /// - The effects returned by local reducer will only be cancelled when `Presented.State` becomes `nil.`
+    ///
+    /// - Returns: `ToPresentedID` transformation.
+    public static func notNil() -> ToPresentedID where ID == Bool {
+      .init { $0 != nil }
+    }
+
+    /// Identifies `Presented.State?` based on `ID` retrieved by key path from `Presented.State?` to `ID`.
+    ///
+    /// - The effects returned by local reducer will be cancelled whenever `ID` changes.
+    ///
+    /// - Parameter `keyPath`: Key path from `Presented.State?` to `ID`.
+    ///
+    /// - Returns: `ToPresentedID` transformation.
+    public static func keyPath(_ keyPath: KeyPath<Presented.State?, ID>) -> ToPresentedID {
+      .init { $0[keyPath: keyPath] }
+    }
+
+    var run: Run
+
+    /// Returns `ID` for provided `Presented.State?`
+    /// - Parameter state: Optional `Presented.State`
+    /// - Returns: `ID`
+    public func callAsFunction(_ state: Presented.State?) -> ID {
+      run(state)
+    }
+  }
+}
+
+extension _PresentingCaseReducer {
+  /// Handles presentation action, like `onPresent` or `onDismiss`.
+  public struct ActionHandler {
+    public typealias Run = (inout Parent.State, Presented.State) -> Effect<Parent.Action, Never>
+
+    /// An action that performs no state mutations and returns no effects.
+    public static var empty: Self { .init { _, _ in .none } }
+
+    public init(run: @escaping Run) {
+      self.run = run
+    }
+
+    var run: Run
+
+    public func callAsFunction(
+      _ parentState: inout Parent.State,
+      _ presentedState: Presented.State
+    ) -> Effect<Parent.Action, Never> {
+      run(&parentState, presentedState)
+    }
+  }
+}

--- a/Tests/ComposablePresentationTests/PresentingCaseReducerTests.swift
+++ b/Tests/ComposablePresentationTests/PresentingCaseReducerTests.swift
@@ -1,0 +1,175 @@
+import CasePaths
+import Combine
+import ComposableArchitecture
+import XCTest
+@testable import ComposablePresentation
+
+final class PresentingCaseReducerTests: XCTestCase {
+  func testPresentingCase() {
+    enum TestAction: Equatable {
+      case didPresentFirst
+      case didFireFirstEffect
+      case didDismissFirst
+      case didCancelFirstEffect
+      case didPresentSecond
+      case didFireSecondEffect
+      case didDismissSecond
+      case didCancelSecondEffect
+    }
+
+    struct Main: ReducerProtocol {
+      struct State: Equatable {
+        enum Destination: Equatable {
+          case first(First.State)
+          case second(Second.State)
+        }
+
+        var destination: Destination?
+      }
+
+      enum Action {
+        case goto(State.Destination?)
+        case first(First.Action)
+        case second(Second.Action)
+      }
+
+      enum Presentation: Hashable {
+        case first
+        case second
+      }
+
+      func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
+        switch action {
+        case .goto(let destination):
+          state.destination = destination
+          return .none
+
+        case .first, .second:
+          return .none
+        }
+      }
+    }
+
+    struct First: ReducerProtocol {
+      struct State: Equatable {}
+      struct Action {}
+
+      var didFireEffect: () -> Void
+      var didCancelEffect: () -> Void
+
+      func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
+        Empty(completeImmediately: false)
+          .handleEvents(
+            receiveSubscription: { _ in didFireEffect() },
+            receiveCancel: { didCancelEffect() }
+          )
+          .eraseToEffect()
+      }
+    }
+
+    struct Second: ReducerProtocol {
+      struct State: Equatable {}
+      struct Action {}
+
+      var didFireEffect: () -> Void
+      var didCancelEffect: () -> Void
+
+      func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
+        Empty(completeImmediately: false)
+          .handleEvents(
+            receiveSubscription: { _ in didFireEffect() },
+            receiveCancel: { didCancelEffect() }
+          )
+          .eraseToEffect()
+      }
+    }
+
+    var actions: [TestAction] = []
+
+    let store = TestStore(
+      initialState: Main.State(),
+      reducer: Main()
+        .presenting(
+          presentationID: Main.Presentation.first,
+          unwrapping: \.destination,
+          case: /Main.State.Destination.first,
+          id: .notNil(),
+          action: /Main.Action.first,
+          onPresent: .init { _, _ in
+            actions.append(.didPresentFirst)
+            return .none
+          },
+          onDismiss: .init { _, _ in
+            actions.append(.didDismissFirst)
+            return .none
+          },
+          presented: {
+            First(
+              didFireEffect: { actions.append(.didFireFirstEffect) },
+              didCancelEffect: { actions.append(.didCancelFirstEffect) }
+            )
+          }
+        )
+        .presenting(
+          presentationID: Main.Presentation.second,
+          unwrapping: \.destination,
+          case: /Main.State.Destination.second,
+          id: .notNil(),
+          action: /Main.Action.second,
+          onPresent: .init { _, _ in
+            actions.append(.didPresentSecond)
+            return .none
+          },
+          onDismiss: .init { _, _ in
+            actions.append(.didDismissSecond)
+            return .none
+          },
+          presented: {
+            Second(
+              didFireEffect: { actions.append(.didFireSecondEffect) },
+              didCancelEffect: { actions.append(.didCancelSecondEffect) }
+            )
+          }
+        )
+    )
+
+    actions = []
+    store.send(.goto(.first(.init()))) {
+      $0.destination = .first(First.State())
+    }
+    XCTAssertNoDifference(actions, [
+      .didPresentFirst,
+    ])
+
+    actions = []
+    store.send(.first(.init()))
+    XCTAssertNoDifference(actions, [
+      .didFireFirstEffect,
+    ])
+
+    actions = []
+    store.send(.goto(.second(.init()))) {
+      $0.destination = .second(.init())
+    }
+    XCTAssertNoDifference(actions, [
+      .didDismissFirst,
+      .didPresentSecond,
+      .didCancelFirstEffect,
+    ])
+
+    actions = []
+    store.send(.second(.init()))
+    XCTAssertNoDifference(actions, [
+      .didFireSecondEffect,
+    ])
+
+    actions = []
+    store.send(.goto(nil)) {
+      $0.destination = nil
+    }
+    XCTAssertNoDifference(actions, [
+      .didDismissSecond,
+      .didCancelSecondEffect,
+    ])
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds `PresentingCaseReducer` for presenting given case of provided enum.

```swift
struct First: ReducerProtocol {
  // ...
}

struct Second: ReducerProtocol {
  // ...
}

struct Main: ReducerProtocol {
  struct State {
    enum Destination {
      case first(First.State)
      case second(Second.State)
    }

    var destination: Destination?
  }

  enum Action {
    case first(First.Action)
    case second(Second.Action)
  }

  var body: some ReducerProtocol<State, Action> {
    // ...
    .presenting(
      unwrapping: \.destination,
      case: /State.Destination.first,
      id: .notNil(),
      action: /Action.first,
      presented: { First() }
    )
    .presenting(
      unwrapping: \.destination,
      case: /State.Destination.second,
      id: .notNil(),
      action: /Action.second,
      presented: { Second() }
    )
  }
}
```

## What was done

- [x] Update package dependencies
- [x] Add `PresentingCaseReducer`
- [x] Add `DestinationExample`
- [x] Add documentation
