### PR TITLE
Add NavigationDestinationWithStore SwiftUI helper

### DIFF
--- a/Sources/ComposablePresentation/NavigationDestinationWithStore.swift
+++ b/Sources/ComposablePresentation/NavigationDestinationWithStore.swift
@@ -1,0 +1,44 @@
+
+import ComposableArchitecture
+import SwiftUI
+
+extension View {
+  /// Associates a destination view with a `Store` (with optional `State`) that can be used to push the view onto a `NavigationStack`.
+  ///
+  /// The sheet is presented if `State?` is non-`nil` and dismissed when it's `nil`.
+  ///
+  /// - Parameters:
+  ///   - store: Store with an optional state.
+  ///   - mapState: Maps the state. Defaults to a closure that returns unchanged state.
+  ///   - onDismiss: Invoked when destination is dismissed.
+  ///   - content: Creates content view with a store with unwrapped state.
+  /// - Returns: View with navigation destination applied.
+  @available(iOS 16.0, *)
+  public func navigationDestination<State, Action, Content: View>(
+    _ store: Store<State?, Action>,
+    mapState: @escaping (State?) -> State? = { $0 },
+    onDismiss: @escaping () -> Void,
+    content: @escaping (Store<State, Action>) -> Content
+  ) -> some View {
+    background {
+      WithViewStore(store.scope(state: { $0 != nil })) { viewStore in
+        EmptyView().navigationDestination(
+          isPresented: Binding(
+            get: { viewStore.state },
+            set: { isPresented in
+              if isPresented == false {
+                onDismiss()
+              }
+            }
+          ),
+          destination: {
+            IfLetStore(
+              store.scope(state: mapState),
+              then: content
+            )
+          }
+        )
+      }
+    }
+  }
+}

--- a/Sources/ComposablePresentation/NavigationDestinationWithStore.swift
+++ b/Sources/ComposablePresentation/NavigationDestinationWithStore.swift
@@ -1,4 +1,3 @@
-
 import ComposableArchitecture
 import SwiftUI
 


### PR DESCRIPTION
## Summary

This PR adds `NavigationDestinationWithStore` SwiftUI helper, which can be used on iOS >= 16. It wraps the native navigation-destination view modifier and drives it with provided store of optional `State` and `Action`.

## What was done

- [x] Add `NavigationDestinationWithStore` SwiftUI helper
- [x] Update `DestinationExample`
