### PR TITLE
Deep link improvements

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,6 +20,10 @@ let package = Package(
       url: "https://github.com/pointfreeco/swift-composable-architecture.git",
       .upToNextMajor(from: "0.47.2")
     ),
+    .package(
+      url: "https://github.com/pointfreeco/swiftui-navigation.git",
+      .upToNextMajor(from: "0.4.5")
+    ),
   ],
   targets: [
     .target(
@@ -28,6 +32,10 @@ let package = Package(
         .product(
           name: "ComposableArchitecture",
           package: "swift-composable-architecture"
+        ),
+        .product(
+          name: "SwiftUINavigation",
+          package: "swiftui-navigation"
         ),
       ]
     ),

--- a/Sources/ComposablePresentation/NavigationDestinationWithStore.swift
+++ b/Sources/ComposablePresentation/NavigationDestinationWithStore.swift
@@ -12,7 +12,7 @@ extension View {
   ///   - onDismiss: Invoked when destination is dismissed.
   ///   - content: Creates content view with a store with unwrapped state.
   /// - Returns: View with navigation destination applied.
-  @available(iOS 16.0, *)
+  @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
   public func navigationDestination<State, Action, Content: View>(
     _ store: Store<State?, Action>,
     mapState: @escaping (State?) -> State? = { $0 },

--- a/Sources/ComposablePresentation/NavigationLinkWithStore.swift
+++ b/Sources/ComposablePresentation/NavigationLinkWithStore.swift
@@ -1,5 +1,6 @@
 import ComposableArchitecture
 import SwiftUI
+import SwiftUINavigation
 
 /// `NavigationLink` wrapped with `WithViewStore`.
 public struct NavigationLinkWithStore<State, Action, Destination, Label>: View
@@ -38,7 +39,7 @@ where Destination: View,
 
   public var body: some View {
     WithViewStore(store.scope(state: { $0 != nil })) { viewStore in
-      NavigationLink(
+      _NavigationLink(
         isActive: Binding(
           get: { viewStore.state },
           set: setActive
@@ -83,5 +84,23 @@ extension NavigationLinkWithStore where Label == EmptyView {
       destination: destination,
       label: EmptyView.init
     )
+  }
+}
+
+// NB: This view works around a bug in SwiftUI's built-in view
+private struct _NavigationLink<Destination: View, Label: View>: View {
+  @Binding var isActive: Bool
+  let destination: () -> Destination
+  let label: () -> Label
+
+  @State private var isActiveState = false
+
+  var body: some View {
+    NavigationLink(
+      isActive: $isActiveState,
+      destination: destination,
+      label: label
+    )
+    .bind($isActive, to: $isActiveState)
   }
 }


### PR DESCRIPTION
## Summary

This PR improves driving presentation from an initially honest (non-nil) state. It should help when implementing deep links.

## What was done

- [x] Add `pointfreeco/swiftui-`navigation dependency.
- [x] Update availability of `NavigationDestinationWithStore` modifier.
- [x] Workaround iOS 16 SwiftUI bug with navigation link and navigation destination.
