### PR TITLE
Dynamic presentation ID

### DIFF
--- a/Example/Example/DestinationExample.swift
+++ b/Example/Example/DestinationExample.swift
@@ -164,11 +164,20 @@ struct DestinationExampleView: View {
               .padding()
           }
 
-          Button {
-            viewStore.send(.alertButtonTapped)
-          } label: {
-            Text("→ Alert")
-              .padding()
+          if #available(iOS 15.0, *) {
+            Button {
+              viewStore.send(.alertButtonTapped)
+            } label: {
+              Text("→ Alert")
+                .padding()
+            }
+            .alert(
+              store.scope(
+                state: { (/DestinationExample.State.Destination.alert).extract(from: $0.destination) },
+                action: DestinationExample.Action.alert
+              ),
+              dismiss: .dismissed
+            )
           }
         }
         .padding()
@@ -187,13 +196,6 @@ struct DestinationExampleView: View {
           ),
           onDismiss: { viewStore.send(.didDismissSecond) },
           destination: SecondView.init(store:)
-        )
-        .alert(
-          store.scope(
-            state: { (/DestinationExample.State.Destination.alert).extract(from: $0.destination) },
-            action: DestinationExample.Action.alert
-          ),
-          dismiss: .dismissed
         )
       }
     }

--- a/Example/Example/DestinationExample.swift
+++ b/Example/Example/DestinationExample.swift
@@ -90,7 +90,7 @@ struct DestinationExample: ReducerProtocol {
       }
     }
     .presenting(
-      presentationID: .static(Presentation.first),
+      presentationID: .value(Presentation.first),
       unwrapping: \.destination,
       case: /State.Destination.first,
       id: .notNil(),
@@ -98,7 +98,7 @@ struct DestinationExample: ReducerProtocol {
       presented: { First() }
     )
     .presenting(
-      presentationID: .static(Presentation.second),
+      presentationID: .value(Presentation.second),
       unwrapping: \.destination,
       case: /State.Destination.second,
       id: .notNil(),

--- a/Example/Example/DestinationExample.swift
+++ b/Example/Example/DestinationExample.swift
@@ -90,7 +90,7 @@ struct DestinationExample: ReducerProtocol {
       }
     }
     .presenting(
-      presentationID: Presentation.first,
+      presentationID: .static(Presentation.first),
       unwrapping: \.destination,
       case: /State.Destination.first,
       id: .notNil(),
@@ -98,7 +98,7 @@ struct DestinationExample: ReducerProtocol {
       presented: { First() }
     )
     .presenting(
-      presentationID: Presentation.second,
+      presentationID: .static(Presentation.second),
       unwrapping: \.destination,
       case: /State.Destination.second,
       id: .notNil(),

--- a/Example/Example/DestinationExample.swift
+++ b/Example/Example/DestinationExample.swift
@@ -30,11 +30,6 @@ struct DestinationExample: ReducerProtocol {
     case alert(Action.Alert)
   }
 
-  enum Presentation: Hashable {
-    case first
-    case second
-  }
-
   var body: some ReducerProtocol<State, Action> {
     Reduce { state, action in
       switch action {
@@ -90,7 +85,6 @@ struct DestinationExample: ReducerProtocol {
       }
     }
     .presenting(
-      presentationID: .value(Presentation.first),
       unwrapping: \.destination,
       case: /State.Destination.first,
       id: .notNil(),
@@ -98,7 +92,6 @@ struct DestinationExample: ReducerProtocol {
       presented: { First() }
     )
     .presenting(
-      presentationID: .value(Presentation.second),
       unwrapping: \.destination,
       case: /State.Destination.second,
       id: .notNil(),

--- a/Example/Example/ForEachStoreExample.swift
+++ b/Example/Example/ForEachStoreExample.swift
@@ -29,7 +29,6 @@ struct ForEachStoreExample: ReducerProtocol {
       }
     }
     .presentingForEach(
-      presentationID: ObjectIdentifier(ForEachStoreExample.self),
       state: \.timers,
       action: /Action.timer(id:action:),
       element: TimerExample.init

--- a/Example/Example/FullScreenCoverExample.swift
+++ b/Example/Example/FullScreenCoverExample.swift
@@ -29,7 +29,6 @@ struct FullScreenCoverExample: ReducerProtocol {
       }
     }
     .presenting(
-      presentationID: ObjectIdentifier(FullScreenCoverExample.self),
       state: .keyPath(\.detail),
       id: .notNil(),
       action: /Action.detail,

--- a/Example/Example/Menu.swift
+++ b/Example/Example/Menu.swift
@@ -71,7 +71,7 @@ extension ReducerProtocolOf<Menu> {
 
   func presentingSheetExample() -> some ReducerProtocol<State, Action> {
     presenting(
-      presentationID: .static(Menu.Presentation.sheet),
+      presentationID: .value(Menu.Presentation.sheet),
       unwrapping: \.destination,
       case: /State.Destination.sheet,
       id: .notNil(),
@@ -82,7 +82,7 @@ extension ReducerProtocolOf<Menu> {
 
   func presentingFullScreenCoverExample() -> some ReducerProtocol<State, Action> {
     presenting(
-      presentationID: .static(Menu.Presentation.fullScreenCover),
+      presentationID: .value(Menu.Presentation.fullScreenCover),
       unwrapping: \.destination,
       case: /State.Destination.fullScreenCover,
       id: .notNil(),
@@ -93,7 +93,7 @@ extension ReducerProtocolOf<Menu> {
 
   func presentingNavigationDestinationExample() -> some ReducerProtocol<State, Action> {
     presenting(
-      presentationID: .static(Menu.Presentation.navigationDestination),
+      presentationID: .value(Menu.Presentation.navigationDestination),
       unwrapping: \.destination,
       case: /State.Destination.navigationDestination,
       id: .notNil(),
@@ -104,7 +104,7 @@ extension ReducerProtocolOf<Menu> {
 
   func presentingForEachStoreExample() -> some ReducerProtocol<State, Action> {
     presenting(
-      presentationID: .static(Menu.Presentation.forEachStore),
+      presentationID: .value(Menu.Presentation.forEachStore),
       unwrapping: \.destination,
       case: /State.Destination.forEachStore,
       id: .notNil(),
@@ -115,7 +115,7 @@ extension ReducerProtocolOf<Menu> {
 
   func presentingPopToRootExample() -> some ReducerProtocol<State, Action> {
     presenting(
-      presentationID: .static(Menu.Presentation.popToRoot),
+      presentationID: .value(Menu.Presentation.popToRoot),
       unwrapping: \.destination,
       case: /State.Destination.popToRoot,
       id: .notNil(),
@@ -126,7 +126,7 @@ extension ReducerProtocolOf<Menu> {
 
   func presentingSwitchStoreExample() -> some ReducerProtocol<State, Action> {
     presenting(
-      presentationID: .static(Menu.Presentation.switchStore),
+      presentationID: .value(Menu.Presentation.switchStore),
       unwrapping: \.destination,
       case: /State.Destination.switchStore,
       id: .notNil(),
@@ -137,7 +137,7 @@ extension ReducerProtocolOf<Menu> {
 
   func presentingDestinationExample() -> some ReducerProtocol<State, Action> {
     presenting(
-      presentationID: .static(Menu.Presentation.destination),
+      presentationID: .value(Menu.Presentation.destination),
       unwrapping: \.destination,
       case: /State.Destination.destination,
       id: .notNil(),

--- a/Example/Example/Menu.swift
+++ b/Example/Example/Menu.swift
@@ -71,7 +71,7 @@ extension ReducerProtocolOf<Menu> {
 
   func presentingSheetExample() -> some ReducerProtocol<State, Action> {
     presenting(
-      presentationID: Menu.Presentation.sheet,
+      presentationID: .static(Menu.Presentation.sheet),
       unwrapping: \.destination,
       case: /State.Destination.sheet,
       id: .notNil(),
@@ -82,7 +82,7 @@ extension ReducerProtocolOf<Menu> {
 
   func presentingFullScreenCoverExample() -> some ReducerProtocol<State, Action> {
     presenting(
-      presentationID: Menu.Presentation.fullScreenCover,
+      presentationID: .static(Menu.Presentation.fullScreenCover),
       unwrapping: \.destination,
       case: /State.Destination.fullScreenCover,
       id: .notNil(),
@@ -93,7 +93,7 @@ extension ReducerProtocolOf<Menu> {
 
   func presentingNavigationDestinationExample() -> some ReducerProtocol<State, Action> {
     presenting(
-      presentationID: Menu.Presentation.navigationDestination,
+      presentationID: .static(Menu.Presentation.navigationDestination),
       unwrapping: \.destination,
       case: /State.Destination.navigationDestination,
       id: .notNil(),
@@ -104,7 +104,7 @@ extension ReducerProtocolOf<Menu> {
 
   func presentingForEachStoreExample() -> some ReducerProtocol<State, Action> {
     presenting(
-      presentationID: Menu.Presentation.forEachStore,
+      presentationID: .static(Menu.Presentation.forEachStore),
       unwrapping: \.destination,
       case: /State.Destination.forEachStore,
       id: .notNil(),
@@ -115,7 +115,7 @@ extension ReducerProtocolOf<Menu> {
 
   func presentingPopToRootExample() -> some ReducerProtocol<State, Action> {
     presenting(
-      presentationID: Menu.Presentation.popToRoot,
+      presentationID: .static(Menu.Presentation.popToRoot),
       unwrapping: \.destination,
       case: /State.Destination.popToRoot,
       id: .notNil(),
@@ -126,7 +126,7 @@ extension ReducerProtocolOf<Menu> {
 
   func presentingSwitchStoreExample() -> some ReducerProtocol<State, Action> {
     presenting(
-      presentationID: Menu.Presentation.switchStore,
+      presentationID: .static(Menu.Presentation.switchStore),
       unwrapping: \.destination,
       case: /State.Destination.switchStore,
       id: .notNil(),
@@ -137,7 +137,7 @@ extension ReducerProtocolOf<Menu> {
 
   func presentingDestinationExample() -> some ReducerProtocol<State, Action> {
     presenting(
-      presentationID: Menu.Presentation.destination,
+      presentationID: .static(Menu.Presentation.destination),
       unwrapping: \.destination,
       case: /State.Destination.destination,
       id: .notNil(),

--- a/Example/Example/Menu.swift
+++ b/Example/Example/Menu.swift
@@ -32,16 +32,6 @@ struct Menu: ReducerProtocol {
     case destination(Menu.Action.Destination)
   }
 
-  enum Presentation: Hashable {
-    case sheet
-    case fullScreenCover
-    case navigationDestination
-    case forEachStore
-    case popToRoot
-    case switchStore
-    case destination
-  }
-
   var body: some ReducerProtocol<State, Action> {
     Reduce { state, action in
       switch action {
@@ -71,7 +61,6 @@ extension ReducerProtocolOf<Menu> {
 
   func presentingSheetExample() -> some ReducerProtocol<State, Action> {
     presenting(
-      presentationID: .value(Menu.Presentation.sheet),
       unwrapping: \.destination,
       case: /State.Destination.sheet,
       id: .notNil(),
@@ -82,7 +71,6 @@ extension ReducerProtocolOf<Menu> {
 
   func presentingFullScreenCoverExample() -> some ReducerProtocol<State, Action> {
     presenting(
-      presentationID: .value(Menu.Presentation.fullScreenCover),
       unwrapping: \.destination,
       case: /State.Destination.fullScreenCover,
       id: .notNil(),
@@ -93,7 +81,6 @@ extension ReducerProtocolOf<Menu> {
 
   func presentingNavigationDestinationExample() -> some ReducerProtocol<State, Action> {
     presenting(
-      presentationID: .value(Menu.Presentation.navigationDestination),
       unwrapping: \.destination,
       case: /State.Destination.navigationDestination,
       id: .notNil(),
@@ -104,7 +91,6 @@ extension ReducerProtocolOf<Menu> {
 
   func presentingForEachStoreExample() -> some ReducerProtocol<State, Action> {
     presenting(
-      presentationID: .value(Menu.Presentation.forEachStore),
       unwrapping: \.destination,
       case: /State.Destination.forEachStore,
       id: .notNil(),
@@ -115,7 +101,6 @@ extension ReducerProtocolOf<Menu> {
 
   func presentingPopToRootExample() -> some ReducerProtocol<State, Action> {
     presenting(
-      presentationID: .value(Menu.Presentation.popToRoot),
       unwrapping: \.destination,
       case: /State.Destination.popToRoot,
       id: .notNil(),
@@ -126,7 +111,6 @@ extension ReducerProtocolOf<Menu> {
 
   func presentingSwitchStoreExample() -> some ReducerProtocol<State, Action> {
     presenting(
-      presentationID: .value(Menu.Presentation.switchStore),
       unwrapping: \.destination,
       case: /State.Destination.switchStore,
       id: .notNil(),
@@ -137,7 +121,6 @@ extension ReducerProtocolOf<Menu> {
 
   func presentingDestinationExample() -> some ReducerProtocol<State, Action> {
     presenting(
-      presentationID: .value(Menu.Presentation.destination),
       unwrapping: \.destination,
       case: /State.Destination.destination,
       id: .notNil(),

--- a/Example/Example/NavigationDestinationExample.swift
+++ b/Example/Example/NavigationDestinationExample.swift
@@ -29,7 +29,6 @@ struct NavigationDestinationExample: ReducerProtocol {
       }
     }
     .presenting(
-      presentationID: ObjectIdentifier(NavigationDestinationExample.self),
       state: .keyPath(\.detail),
       id: .notNil(),
       action: /Action.detail,

--- a/Example/Example/PopToRootExample.swift
+++ b/Example/Example/PopToRootExample.swift
@@ -42,7 +42,6 @@ struct PopToRootExample: ReducerProtocol {
       }
     }
     .presenting(
-      presentationID: ObjectIdentifier(PopToRootExample.self),
       state: .keyPath(\.first),
       id: .notNil(),
       action: /Action.first,
@@ -85,7 +84,6 @@ struct PopToRootExample: ReducerProtocol {
         }
       }
       .presenting(
-        presentationID: ObjectIdentifier(First.self),
         state: .keyPath(\.second),
         id: .notNil(),
         action: /First.Action.second,

--- a/Example/Example/SheetExample.swift
+++ b/Example/Example/SheetExample.swift
@@ -33,7 +33,6 @@ struct SheetExample: ReducerProtocol {
       }
     }
     .presenting(
-      presentationID: ObjectIdentifier(SheetExample.self),
       state: .keyPath(\.detail),
       id: .notNil(),
       action: /Action.detail,

--- a/Example/Example/SwitchStoreExample.swift
+++ b/Example/Example/SwitchStoreExample.swift
@@ -52,14 +52,14 @@ struct SwitchStoreExample: ReducerProtocol {
       }
     }
     .presenting(
-      presentationID: Presentation.first,
+      presentationID: .static(Presentation.first),
       state: .casePath(/State.first),
       id: .notNil(),
       action: /Action.first,
       presented: First.init
     )
     .presenting(
-      presentationID: Presentation.second,
+      presentationID: .static(Presentation.second),
       state: .casePath(/State.second),
       id: .notNil(),
       action: /Action.second,

--- a/Example/Example/SwitchStoreExample.swift
+++ b/Example/Example/SwitchStoreExample.swift
@@ -52,14 +52,14 @@ struct SwitchStoreExample: ReducerProtocol {
       }
     }
     .presenting(
-      presentationID: .static(Presentation.first),
+      presentationID: .value(Presentation.first),
       state: .casePath(/State.first),
       id: .notNil(),
       action: /Action.first,
       presented: First.init
     )
     .presenting(
-      presentationID: .static(Presentation.second),
+      presentationID: .value(Presentation.second),
       state: .casePath(/State.second),
       id: .notNil(),
       action: /Action.second,

--- a/Example/Example/SwitchStoreExample.swift
+++ b/Example/Example/SwitchStoreExample.swift
@@ -30,11 +30,6 @@ struct SwitchStoreExample: ReducerProtocol {
     case second(Second.Action)
   }
 
-  enum Presentation: Hashable {
-    case first
-    case second
-  }
-
   var body: some ReducerProtocol<State, Action> {
     Reduce { state, action in
       switch action {
@@ -52,14 +47,12 @@ struct SwitchStoreExample: ReducerProtocol {
       }
     }
     .presenting(
-      presentationID: .value(Presentation.first),
       state: .casePath(/State.first),
       id: .notNil(),
       action: /Action.first,
       presented: First.init
     )
     .presenting(
-      presentationID: .value(Presentation.second),
       state: .casePath(/State.second),
       id: .notNil(),
       action: /Action.second,

--- a/Sources/ComposablePresentation/PresentationID.swift
+++ b/Sources/ComposablePresentation/PresentationID.swift
@@ -1,0 +1,39 @@
+/// `State` → presentation identifier transformation for `.presenting` higher order reducers.
+public struct ToPresentationID<State> {
+  public typealias Run = (State) -> AnyHashable
+
+  /// Identifier presentation with the provided static identifier.
+  ///
+  /// - Parameter id: Unique identifier
+  /// - Returns: Transformation.
+  public static func `static`(_ id: AnyHashable) -> ToPresentationID<State> {
+    .init { _ in id }
+  }
+
+  /// Identifies presentation by type of `State`
+  ///
+  /// - Returns: Transformation.
+  public static func typeId() -> ToPresentationID<State> {
+    .init { ObjectIdentifier(type(of: $0)) }
+  }
+
+  /// Identifies presentation with value of `State` at provided key path.
+  ///
+  /// - Parameter keyPath: The key path for unique presentation identifier.
+  /// - Returns: Transformation.
+  public static func keyPath(
+    _ keyPath: KeyPath<State?, AnyHashable>
+  ) -> ToPresentationID<State> {
+    .init { $0[keyPath: keyPath] }
+  }
+
+  public init(run: @escaping Run) {
+    self.run = run
+  }
+
+  public var run: Run
+
+  public func callAsFunction(_ state: State) -> AnyHashable {
+    run(state)
+  }
+}

--- a/Sources/ComposablePresentation/PresentationID.swift
+++ b/Sources/ComposablePresentation/PresentationID.swift
@@ -6,15 +6,15 @@ public struct ToPresentationID<State> {
   ///
   /// - Parameter id: Unique identifier
   /// - Returns: Transformation.
-  public static func `static`(_ id: AnyHashable) -> ToPresentationID<State> {
+  public static func value(_ id: AnyHashable) -> ToPresentationID<State> {
     .init { _ in id }
   }
 
-  /// Identifies presentation by type of `State`
+  /// Identifies presentation by type of `(State, Presented)`
   ///
   /// - Returns: Transformation.
-  public static func typeId() -> ToPresentationID<State> {
-    .init { ObjectIdentifier(type(of: $0)) }
+  public static func typed<Presented>(_ presentedType: Presented.Type) -> ToPresentationID<State> {
+    .init { _ in ObjectIdentifier(type(of: (State.self, presentedType))) }
   }
 
   /// Identifies presentation with value of `State` at provided key path.

--- a/Sources/ComposablePresentation/PresentingCaseReducer.swift
+++ b/Sources/ComposablePresentation/PresentingCaseReducer.swift
@@ -7,7 +7,7 @@ extension ReducerProtocol {
   /// - All effects returned by the presented reducer are cancelled when presented `ID` changes.
   ///
   /// - Parameters:
-  ///   - presentationID: Unique identifier for the presentation. Defaults to a new UUID.
+  ///   - toPresentationID: Transformation from `State` to unique identifier. Defaults to transformation that identifies object by type of `State`.
   ///   - toEnum: Writable key-path from `State` to optional `Enum`.
   ///   - toCase: Case path from `Enum` to `Presented.State`.
   ///   - toPresentedID: Transformation from `Presented.State` to `ID`.
@@ -18,7 +18,7 @@ extension ReducerProtocol {
   /// - Returns: Combined reducer
   @inlinable
   public func presenting<ID: Hashable, Enum, Presented: ReducerProtocol>(
-    presentationID: AnyHashable = UUID(),
+    presentationID toPresentationID: ToPresentationID<State> = .typeId(),
     unwrapping toEnum: WritableKeyPath<State, Enum?>,
     case toCase: CasePath<Enum, Presented.State>,
     id toPresentedID: _PresentingCaseReducer<Self, Enum, ID, Presented>.ToPresentedID,
@@ -31,9 +31,9 @@ extension ReducerProtocol {
     line: UInt = #line
   ) -> _PresentingCaseReducer<Self, Enum, ID, Presented> {
     .init(
-      presentationID: presentationID,
       parent: self,
       presented: presented(),
+      toPresentationID: toPresentationID,
       toEnum: toEnum,
       toCase: toCase,
       toPresentedID: toPresentedID,
@@ -54,13 +54,13 @@ public struct _PresentingCaseReducer<
   Presented: ReducerProtocol
 >: ReducerProtocol {
   @usableFromInline
-  let presentationID: AnyHashable
-
-  @usableFromInline
   let parent: Parent
 
   @usableFromInline
   let presented: Presented
+
+  @usableFromInline
+  let toPresentationID: ToPresentationID<State>
 
   @usableFromInline
   let toEnum: WritableKeyPath<Parent.State, Enum?>
@@ -91,9 +91,9 @@ public struct _PresentingCaseReducer<
 
   @inlinable
   init(
-    presentationID: AnyHashable,
     parent: Parent,
     presented: Presented,
+    toPresentationID: ToPresentationID<State>,
     toEnum: WritableKeyPath<State, Enum?>,
     toCase: CasePath<Enum, Presented.State>,
     toPresentedID: ToPresentedID,
@@ -104,9 +104,9 @@ public struct _PresentingCaseReducer<
     fileID: StaticString,
     line: UInt
   ) {
-    self.presentationID = presentationID
     self.parent = parent
     self.presented = presented
+    self.toPresentationID = toPresentationID
     self.toEnum = toEnum
     self.toCase = toCase
     self.toPresentedID = toPresentedID
@@ -133,7 +133,7 @@ public struct _PresentingCaseReducer<
     let oldPresentedID = toPresentedID.run(oldPresentedState)
 
     let presentedEffectsID = PresentingReducerEffectId(
-      presentationID: presentationID,
+      presentationID: toPresentationID(oldState),
       presentedID: oldPresentedID
     )
     let shouldRunPresented = toPresentedAction.extract(from: action) != nil

--- a/Sources/ComposablePresentation/PresentingCaseReducer.swift
+++ b/Sources/ComposablePresentation/PresentingCaseReducer.swift
@@ -7,7 +7,7 @@ extension ReducerProtocol {
   /// - All effects returned by the presented reducer are cancelled when presented `ID` changes.
   ///
   /// - Parameters:
-  ///   - toPresentationID: Transformation from `State` to unique identifier. Defaults to transformation that identifies object by type of `State`.
+  ///   - toPresentationID: Transformation from `State` to unique identifier. Defaults to transformation that identifies object by type of `(State, Presented)`.
   ///   - toEnum: Writable key-path from `State` to optional `Enum`.
   ///   - toCase: Case path from `Enum` to `Presented.State`.
   ///   - toPresentedID: Transformation from `Presented.State` to `ID`.
@@ -18,7 +18,7 @@ extension ReducerProtocol {
   /// - Returns: Combined reducer
   @inlinable
   public func presenting<ID: Hashable, Enum, Presented: ReducerProtocol>(
-    presentationID toPresentationID: ToPresentationID<State> = .typeId(),
+    presentationID toPresentationID: ToPresentationID<State> = .typed(Presented.self),
     unwrapping toEnum: WritableKeyPath<State, Enum?>,
     case toCase: CasePath<Enum, Presented.State>,
     id toPresentedID: _PresentingCaseReducer<Self, Enum, ID, Presented>.ToPresentedID,

--- a/Sources/ComposablePresentation/PresentingForEachReducer.swift
+++ b/Sources/ComposablePresentation/PresentingForEachReducer.swift
@@ -9,7 +9,7 @@ extension ReducerProtocol {
   /// - Inspired by [Reducer.presents function](https://github.com/pointfreeco/swift-composable-architecture/blob/9ec4b71e5a84f448dedb063a21673e4696ce135f/Sources/ComposableArchitecture/Reducer.swift#L549-L572) from `iso` branch of `swift-composable-architecture` repository.
   ///
   /// - Parameters:
-  ///   - toPresentationID: Transformation from `State` to unique identifier. Defaults to transformation that identifies object by type of `State`.
+  ///   - toPresentationID: Transformation from `State` to unique identifier. Defaults to transformation that identifies object by type of `(State, Element)`.
   ///   - state: A key path form parent state to identified array that hold element states.
   ///   - action: A case path that can extract/embed element action from parent.
   ///   - onPresent: An action run when element is added to identified array. Defaults to empty action.
@@ -18,7 +18,7 @@ extension ReducerProtocol {
   /// - Returns: Combined reducer.
   @inlinable
   public func presentingForEach<ID: Hashable, Element: ReducerProtocol>(
-    presentationID toPresentationID: ToPresentationID<State> = .typeId(),
+    presentationID toPresentationID: ToPresentationID<State> = .typed(Element.self),
     state toElementState: WritableKeyPath<State, IdentifiedArray<ID, Element.State>>,
     action toElementAction: CasePath<Action, (ID, Element.Action)>,
     onPresent: PresentingForEachReducerAction<ID, State, Action> = .empty,

--- a/Sources/ComposablePresentation/PresentingForEachReducer.swift
+++ b/Sources/ComposablePresentation/PresentingForEachReducer.swift
@@ -9,7 +9,7 @@ extension ReducerProtocol {
   /// - Inspired by [Reducer.presents function](https://github.com/pointfreeco/swift-composable-architecture/blob/9ec4b71e5a84f448dedb063a21673e4696ce135f/Sources/ComposableArchitecture/Reducer.swift#L549-L572) from `iso` branch of `swift-composable-architecture` repository.
   ///
   /// - Parameters:
-  ///   - presentationID: Unique identifier for the presentation. Defaults to new UUID.
+  ///   - toPresentationID: Transformation from `State` to unique identifier. Defaults to transformation that identifies object by type of `State`.
   ///   - state: A key path form parent state to identified array that hold element states.
   ///   - action: A case path that can extract/embed element action from parent.
   ///   - onPresent: An action run when element is added to identified array. Defaults to empty action.
@@ -18,7 +18,7 @@ extension ReducerProtocol {
   /// - Returns: Combined reducer.
   @inlinable
   public func presentingForEach<ID: Hashable, Element: ReducerProtocol>(
-    presentationID: AnyHashable = UUID(),
+    presentationID toPresentationID: ToPresentationID<State> = .typeId(),
     state toElementState: WritableKeyPath<State, IdentifiedArray<ID, Element.State>>,
     action toElementAction: CasePath<Action, (ID, Element.Action)>,
     onPresent: PresentingForEachReducerAction<ID, State, Action> = .empty,
@@ -29,8 +29,8 @@ extension ReducerProtocol {
     line: UInt = #line
   ) -> _PresentingForEachReducer<Self, ID, Element> {
     .init(
-      presentationID: presentationID,
       parent: self,
+      toPresentationID: toPresentationID,
       toElementState: toElementState,
       toElementAction: toElementAction,
       onPresent: onPresent,
@@ -49,10 +49,10 @@ public struct _PresentingForEachReducer<
   Element: ReducerProtocol
 >: ReducerProtocol {
   @usableFromInline
-  let presentationID: AnyHashable
+  let parent: Parent
 
   @usableFromInline
-  let parent: Parent
+  let toPresentationID: ToPresentationID<State>
 
   @usableFromInline
   let toElementState: WritableKeyPath<Parent.State, IdentifiedArray<ID, Element.State>>
@@ -80,8 +80,8 @@ public struct _PresentingForEachReducer<
 
   @inlinable
   init(
-    presentationID: AnyHashable,
     parent: Parent,
+    toPresentationID: ToPresentationID<State>,
     toElementState: WritableKeyPath<Parent.State, IdentifiedArray<ID, Element.State>>,
     toElementAction: CasePath<Parent.Action, (ID, Element.Action)>,
     onPresent: PresentingForEachReducerAction<ID, State, Action> = .empty,
@@ -91,8 +91,8 @@ public struct _PresentingForEachReducer<
     fileID: StaticString = #fileID,
     line: UInt = #line
   ) {
-    self.presentationID = presentationID
     self.parent = parent
+    self.toPresentationID = toPresentationID
     self.toElementState = toElementState
     self.toElementAction = toElementAction
     self.onPresent = onPresent
@@ -115,7 +115,10 @@ public struct _PresentingForEachReducer<
     }
 
     func effectID(for id: ID) -> PresentingForEachReducerEffectID {
-      .init(presentationID: presentationID, elementID: id)
+      .init(
+        presentationID: toPresentationID(state),
+        elementID: id
+      )
     }
 
     let oldIds = state[keyPath: toElementState].ids

--- a/Sources/ComposablePresentation/PresentingReducer.swift
+++ b/Sources/ComposablePresentation/PresentingReducer.swift
@@ -7,7 +7,7 @@ extension ReducerProtocol {
   /// - All effects returned by the presented reducer are cancelled when presented `ID` changes.
   ///
   /// - Parameters:
-  ///   - toPresentationID: Transformation from `State` to unique identifier. Defaults to transformation that identifies object by type of `State`.
+  ///   - toPresentationID: Transformation from `State` to unique identifier. Defaults to transformation that identifies object by type of `(State, Presented)`.
   ///   - state: `PresentingReducerToPresentedState` that can get/set presented state in parent.
   ///   - id: `PresentingReducerToPresentedID` that returns `ID` for given presented state.
   ///   - action: A case path that can extract/embed presented action from parent.
@@ -17,7 +17,7 @@ extension ReducerProtocol {
   /// - Returns: Combined reducer.
   @inlinable
   public func presenting<ID: Hashable, Presented: ReducerProtocol>(
-    presentationID toPresentationID: ToPresentationID<State> = .typeId(),
+    presentationID toPresentationID: ToPresentationID<State> = .typed(Presented.self),
     state toPresentedState: PresentingReducerToPresentedState<State, Presented.State>,
     id toPresentedID: PresentingReducerToPresentedID<Presented.State, ID>,
     action toPresentedAction: CasePath<Action, Presented.Action>,

--- a/Sources/ComposablePresentation/Reducer+Presenting.swift
+++ b/Sources/ComposablePresentation/Reducer+Presenting.swift
@@ -41,11 +41,11 @@ extension AnyReducer {
   ) -> Self {
     AnyReducer { state, action, env in
       _PresentingReducer(
-        presentationID: presentationID,
         parent: Reduce(AnyReducer(self.run), environment: env),
         presented: Reduce { state, action in
           localReducer.run(&state, action, toLocalEnvironment(env))
         },
+        toPresentationID: .static(presentationID),
         toPresentedState: {
           switch toLocalState {
           case .keyPath(let keyPath): return .keyPath(keyPath)

--- a/Sources/ComposablePresentation/Reducer+Presenting.swift
+++ b/Sources/ComposablePresentation/Reducer+Presenting.swift
@@ -45,7 +45,7 @@ extension AnyReducer {
         presented: Reduce { state, action in
           localReducer.run(&state, action, toLocalEnvironment(env))
         },
-        toPresentationID: .static(presentationID),
+        toPresentationID: .value(presentationID),
         toPresentedState: {
           switch toLocalState {
           case .keyPath(let keyPath): return .keyPath(keyPath)

--- a/Sources/ComposablePresentation/Reducer+PresentingForEach.swift
+++ b/Sources/ComposablePresentation/Reducer+PresentingForEach.swift
@@ -41,8 +41,8 @@ extension AnyReducer {
   ) -> Self {
     AnyReducer { state, action, env in
       _PresentingForEachReducer(
-        presentationID: presentationID,
         parent: Reduce(AnyReducer(self.run), environment: env),
+        toPresentationID: .static(presentationID),
         toElementState: toLocalState,
         toElementAction: toLocalAction,
         onPresent: .init { elementId, state in

--- a/Sources/ComposablePresentation/Reducer+PresentingForEach.swift
+++ b/Sources/ComposablePresentation/Reducer+PresentingForEach.swift
@@ -42,7 +42,7 @@ extension AnyReducer {
     AnyReducer { state, action, env in
       _PresentingForEachReducer(
         parent: Reduce(AnyReducer(self.run), environment: env),
-        toPresentationID: .static(presentationID),
+        toPresentationID: .value(presentationID),
         toElementState: toLocalState,
         toElementAction: toLocalAction,
         onPresent: .init { elementId, state in

--- a/Tests/ComposablePresentationTests/PresentingCaseReducerTests.swift
+++ b/Tests/ComposablePresentationTests/PresentingCaseReducerTests.swift
@@ -90,7 +90,7 @@ final class PresentingCaseReducerTests: XCTestCase {
       initialState: Main.State(),
       reducer: Main()
         .presenting(
-          presentationID: Main.Presentation.first,
+          presentationID: .static(Main.Presentation.first),
           unwrapping: \.destination,
           case: /Main.State.Destination.first,
           id: .notNil(),
@@ -111,7 +111,7 @@ final class PresentingCaseReducerTests: XCTestCase {
           }
         )
         .presenting(
-          presentationID: Main.Presentation.second,
+          presentationID: .static(Main.Presentation.second),
           unwrapping: \.destination,
           case: /Main.State.Destination.second,
           id: .notNil(),

--- a/Tests/ComposablePresentationTests/PresentingCaseReducerTests.swift
+++ b/Tests/ComposablePresentationTests/PresentingCaseReducerTests.swift
@@ -33,11 +33,6 @@ final class PresentingCaseReducerTests: XCTestCase {
         case second(Second.Action)
       }
 
-      enum Presentation: Hashable {
-        case first
-        case second
-      }
-
       func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
         switch action {
         case .goto(let destination):
@@ -90,7 +85,6 @@ final class PresentingCaseReducerTests: XCTestCase {
       initialState: Main.State(),
       reducer: Main()
         .presenting(
-          presentationID: .value(Main.Presentation.first),
           unwrapping: \.destination,
           case: /Main.State.Destination.first,
           id: .notNil(),
@@ -111,7 +105,6 @@ final class PresentingCaseReducerTests: XCTestCase {
           }
         )
         .presenting(
-          presentationID: .value(Main.Presentation.second),
           unwrapping: \.destination,
           case: /Main.State.Destination.second,
           id: .notNil(),

--- a/Tests/ComposablePresentationTests/PresentingCaseReducerTests.swift
+++ b/Tests/ComposablePresentationTests/PresentingCaseReducerTests.swift
@@ -90,7 +90,7 @@ final class PresentingCaseReducerTests: XCTestCase {
       initialState: Main.State(),
       reducer: Main()
         .presenting(
-          presentationID: .static(Main.Presentation.first),
+          presentationID: .value(Main.Presentation.first),
           unwrapping: \.destination,
           case: /Main.State.Destination.first,
           id: .notNil(),
@@ -111,7 +111,7 @@ final class PresentingCaseReducerTests: XCTestCase {
           }
         )
         .presenting(
-          presentationID: .static(Main.Presentation.second),
+          presentationID: .value(Main.Presentation.second),
           unwrapping: \.destination,
           case: /Main.State.Destination.second,
           id: .notNil(),


### PR DESCRIPTION
## What was done

- [x] Add `ToPresentationID<State>` transformation to use in place of limited `AnyHashable`.
- [x] Provide `ToPresentationID` that identifies presentation by:
  - [x] Provided `AnyHashable` value.
  - [x] Type of `(State, <#Presented#>)`
  - [x] Value of `State` at provided keypath.
- [x] Update example app.
