### PR TITLE
Clean up dependencies

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,10 +20,6 @@ let package = Package(
       url: "https://github.com/pointfreeco/swift-composable-architecture.git",
       .upToNextMajor(from: "0.47.2")
     ),
-    .package(
-      url: "https://github.com/pointfreeco/swiftui-navigation.git",
-      .upToNextMajor(from: "0.4.5")
-    ),
   ],
   targets: [
     .target(
@@ -32,10 +28,6 @@ let package = Package(
         .product(
           name: "ComposableArchitecture",
           package: "swift-composable-architecture"
-        ),
-        .product(
-          name: "SwiftUINavigation",
-          package: "swiftui-navigation"
         ),
       ]
     ),

--- a/Sources/ComposablePresentation/NavigationDestinationWithStore.swift
+++ b/Sources/ComposablePresentation/NavigationDestinationWithStore.swift
@@ -1,6 +1,5 @@
 import ComposableArchitecture
 import SwiftUI
-import SwiftUINavigation
 
 extension View {
   /// Associates a destination view with a `Store` (with optional `State`) that can be used to push the view onto a `NavigationStack`.
@@ -40,24 +39,5 @@ extension View {
         ))
       }
     }
-  }
-}
-
-// NB: This view modifier works around a bug in SwiftUI's built-in modifier:
-// https://gist.github.com/mbrandonw/f8b94957031160336cac6898a919cbb7#file-fb11056434-md
-@available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
-private struct _NavigationDestination<Destination: View>: ViewModifier {
-  @Binding var isPresented: Bool
-  let destination: () -> Destination
-
-  @State private var isPresentedState = false
-
-  func body(content: Content) -> some View {
-    content
-      .navigationDestination(
-        isPresented: $isPresentedState,
-        destination: destination
-      )
-      .bind($isPresented, to: $isPresentedState)
   }
 }

--- a/Sources/ComposablePresentation/NavigationLinkWithStore.swift
+++ b/Sources/ComposablePresentation/NavigationLinkWithStore.swift
@@ -1,6 +1,5 @@
 import ComposableArchitecture
 import SwiftUI
-import SwiftUINavigation
 
 /// `NavigationLink` wrapped with `WithViewStore`.
 @available(iOS, deprecated: 16.0, message: "use .navigationDestination(_:mapState:onDismiss:content:) view modifier (aka NavigationDestinationWithStore) inside a NavigationStack or NavigationSplitView")
@@ -86,23 +85,5 @@ extension NavigationLinkWithStore where Label == EmptyView {
       destination: destination,
       label: EmptyView.init
     )
-  }
-}
-
-// NB: This view works around a bug in SwiftUI's built-in view
-private struct _NavigationLink<Destination: View, Label: View>: View {
-  @Binding var isActive: Bool
-  let destination: () -> Destination
-  let label: () -> Label
-
-  @State private var isActiveState = false
-
-  var body: some View {
-    NavigationLink(
-      isActive: $isActiveState,
-      destination: destination,
-      label: label
-    )
-    .bind($isActive, to: $isActiveState)
   }
 }

--- a/Sources/ComposablePresentation/_SwiftUINavigation.swift
+++ b/Sources/ComposablePresentation/_SwiftUINavigation.swift
@@ -1,0 +1,107 @@
+/// MIT License
+///
+/// Copyright (c) 2021 Point-Free, Inc.
+///
+/// Permission is hereby granted, free of charge, to any person obtaining a copy
+/// of this software and associated documentation files (the "Software"), to deal
+/// in the Software without restriction, including without limitation the rights
+/// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+/// copies of the Software, and to permit persons to whom the Software is
+/// furnished to do so, subject to the following conditions:
+///
+/// The above copyright notice and this permission notice shall be included in all
+/// copies or substantial portions of the Software.
+///
+/// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+/// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+/// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+/// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+/// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+/// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+/// SOFTWARE.
+
+import SwiftUI
+
+// NB: This view works around a bug in SwiftUI's built-in view
+struct _NavigationLink<Destination: View, Label: View>: View {
+  @Binding var isActive: Bool
+  let destination: () -> Destination
+  let label: () -> Label
+
+  @State private var isActiveState = false
+
+  var body: some View {
+    NavigationLink(
+      isActive: $isActiveState,
+      destination: destination,
+      label: label
+    )
+    .bind($isActive, to: $isActiveState)
+  }
+}
+
+// NB: This view modifier works around a bug in SwiftUI's built-in modifier:
+// https://gist.github.com/mbrandonw/f8b94957031160336cac6898a919cbb7#file-fb11056434-md
+@available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
+struct _NavigationDestination<Destination: View>: ViewModifier {
+  @Binding var isPresented: Bool
+  let destination: () -> Destination
+
+  @State private var isPresentedState = false
+
+  func body(content: Content) -> some View {
+    content
+      .navigationDestination(
+        isPresented: $isPresentedState,
+        destination: destination
+      )
+      .bind($isPresented, to: $isPresentedState)
+  }
+}
+
+extension View {
+  @available(iOS 14, macOS 11, tvOS 14, watchOS 7, *)
+  func bind<ModelValue: _Bindable, ViewValue: _Bindable>(
+    _ modelValue: ModelValue, to viewValue: ViewValue
+  ) -> some View
+  where ModelValue.Value == ViewValue.Value, ModelValue.Value: Equatable {
+    self.modifier(_Bind(modelValue: modelValue, viewValue: viewValue))
+  }
+}
+
+@available(iOS 14, macOS 11, tvOS 14, watchOS 7, *)
+private struct _Bind<ModelValue: _Bindable, ViewValue: _Bindable>: ViewModifier
+where ModelValue.Value == ViewValue.Value, ModelValue.Value: Equatable {
+  let modelValue: ModelValue
+  let viewValue: ViewValue
+
+  @State var hasAppeared = false
+
+  func body(content: Content) -> some View {
+    content
+      .onAppear {
+        guard !self.hasAppeared else { return }
+        self.hasAppeared = true
+        guard self.viewValue.wrappedValue != self.modelValue.wrappedValue else { return }
+        self.viewValue.wrappedValue = self.modelValue.wrappedValue
+      }
+      .onChange(of: self.modelValue.wrappedValue) {
+        guard self.viewValue.wrappedValue != $0
+        else { return }
+        self.viewValue.wrappedValue = $0
+      }
+      .onChange(of: self.viewValue.wrappedValue) {
+        guard self.modelValue.wrappedValue != $0
+        else { return }
+        self.modelValue.wrappedValue = $0
+      }
+  }
+}
+
+protocol _Bindable {
+  associatedtype Value
+  var wrappedValue: Value { get nonmutating set }
+}
+
+extension Binding: _Bindable {}
+extension State: _Bindable {}


### PR DESCRIPTION
## What was done

- [x] Use an internal copy of [swiftui-navigation] helpers, instead of depending on the library.
