### PR TITLE
Navigation stack example

### DIFF
--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		3154EC1526DFD1F500D69F22 /* ComposablePresentation in Frameworks */ = {isa = PBXBuildFile; productRef = 3154EC1426DFD1F500D69F22 /* ComposablePresentation */; };
 		3154EC1726DFD41700D69F22 /* App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3154EC1626DFD41700D69F22 /* App.swift */; };
 		3156F63F274253D700CA965F /* SwitchStoreExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3156F63E274253D700CA965F /* SwitchStoreExample.swift */; };
+		315A243D2963ADB900B04EAC /* NavigationStackExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 315A243C2963ADB900B04EAC /* NavigationStackExample.swift */; };
 		31817E682950A982000BC1C3 /* DestinationExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31817E672950A982000BC1C3 /* DestinationExample.swift */; };
 		3195775C27415EF100FFA9EB /* PopToRootExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3195775B27415EF100FFA9EB /* PopToRootExample.swift */; };
 		31B556892961CE500022203B /* Menu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31B556882961CE500022203B /* Menu.swift */; };
@@ -29,6 +30,7 @@
 		3154EC0D26DFD01800D69F22 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		3154EC1626DFD41700D69F22 /* App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App.swift; sourceTree = "<group>"; };
 		3156F63E274253D700CA965F /* SwitchStoreExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchStoreExample.swift; sourceTree = "<group>"; };
+		315A243C2963ADB900B04EAC /* NavigationStackExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationStackExample.swift; sourceTree = "<group>"; };
 		31817E672950A982000BC1C3 /* DestinationExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DestinationExample.swift; sourceTree = "<group>"; };
 		3195775B27415EF100FFA9EB /* PopToRootExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopToRootExample.swift; sourceTree = "<group>"; };
 		31B556882961CE500022203B /* Menu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Menu.swift; sourceTree = "<group>"; };
@@ -79,6 +81,7 @@
 				3195775B27415EF100FFA9EB /* PopToRootExample.swift */,
 				3156F63E274253D700CA965F /* SwitchStoreExample.swift */,
 				31817E672950A982000BC1C3 /* DestinationExample.swift */,
+				315A243C2963ADB900B04EAC /* NavigationStackExample.swift */,
 				31D7D9B52740909C001699F4 /* TimerExample.swift */,
 				3103A61929621FA500B15453 /* Helpers.swift */,
 				3154EC0826DFD01800D69F22 /* Assets.xcassets */,
@@ -163,6 +166,7 @@
 				31D7D9B42740907F001699F4 /* NavigationDestinationExample.swift in Sources */,
 				3195775C27415EF100FFA9EB /* PopToRootExample.swift in Sources */,
 				31D7D9BC274099F2001699F4 /* SheetExample.swift in Sources */,
+				315A243D2963ADB900B04EAC /* NavigationStackExample.swift in Sources */,
 				3156F63F274253D700CA965F /* SwitchStoreExample.swift in Sources */,
 				31D7D9BA274096B6001699F4 /* ForEachStoreExample.swift in Sources */,
 				3103A61A29621FA500B15453 /* Helpers.swift in Sources */,

--- a/Example/Example/Menu.swift
+++ b/Example/Example/Menu.swift
@@ -12,6 +12,7 @@ struct Menu: ReducerProtocol {
       case popToRoot(PopToRootExample.State)
       case switchStore(SwitchStoreExample.State)
       case destination(DestinationExample.State)
+      case navigationStack(NavigationStackExample.State)
     }
 
     var destination: Menu.State.Destination?
@@ -26,6 +27,7 @@ struct Menu: ReducerProtocol {
       case popToRoot(PopToRootExample.Action)
       case switchStore(SwitchStoreExample.Action)
       case destination(DestinationExample.Action)
+      case navigationStack(NavigationStackExample.Action)
     }
 
     case present(Menu.State.Destination?)
@@ -57,6 +59,7 @@ extension ReducerProtocolOf<Menu> {
       .presentingPopToRootExample()
       .presentingSwitchStoreExample()
       .presentingDestinationExample()
+      .presentingNavigationStackExample()
   }
 
   func presentingSheetExample() -> some ReducerProtocol<State, Action> {
@@ -128,6 +131,16 @@ extension ReducerProtocolOf<Menu> {
       presented: DestinationExample.init
     )
   }
+
+  func presentingNavigationStackExample() -> some ReducerProtocol<State, Action> {
+    presenting(
+      unwrapping: \.destination,
+      case: /State.Destination.navigationStack,
+      id: .notNil(),
+      action: (/Action.destination).appending(path: /Action.Destination.navigationStack),
+      presented: NavigationStackExample.init
+    )
+  }
 }
 
 struct MenuView: View {
@@ -174,6 +187,11 @@ struct MenuView: View {
                 state: (/Menu.State.Destination.destination).extract(from:),
                 action: { Menu.Action.destination(.destination($0)) },
                 then: DestinationExampleView.init(store:)
+              )
+              CaseLet(
+                state: (/Menu.State.Destination.navigationStack).extract(from:),
+                action: { Menu.Action.destination(.navigationStack($0)) },
+                then: NavigationStackExampleView.init(store:)
               )
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -230,6 +248,12 @@ struct MenuView: View {
                 viewStore.send(.present(.destination(.init())))
               } label: {
                 Text("DestinationExample")
+              }
+
+              Button {
+                viewStore.send(.present(.navigationStack(.init())))
+              } label: {
+                Text("NavigationStackExample")
               }
             } header: {
               Text("Examples")

--- a/Example/Example/NavigationStackExample.swift
+++ b/Example/Example/NavigationStackExample.swift
@@ -66,7 +66,8 @@ struct NavigationStackExample: ReducerProtocol {
       state: \.stack,
       action: /Action.destination,
       onPresent: .init { id, state in
-        .task { .destination(id, .timer(.didAppear)) }
+        // Start timer when destination is added to the stack. When multiple destinations are pushed onto the stack, only the view of the last one will receive `.onAppear` event (that starts the timer too).
+        .task { .destination(id, .timer(.start)) }
       },
       element: Destination.init
     )

--- a/Example/Example/NavigationStackExample.swift
+++ b/Example/Example/NavigationStackExample.swift
@@ -11,7 +11,7 @@ struct NavigationStackExample: ReducerProtocol {
 
   enum Action {
     case updatePath(State.Path)
-    case push
+    case start
     case popToRoot
     case popTo(State.Path.Element)
     case destination(_ id: Destination.State.ID, _ action: Destination.Action)
@@ -26,7 +26,7 @@ struct NavigationStackExample: ReducerProtocol {
         }
         return .none
 
-      case .push:
+      case .start:
         state.stack = [.init(id: "1")]
         return .none
 
@@ -108,9 +108,9 @@ struct NavigationStackExampleView: View {
             send: NavigationStackExample.Action.updatePath
           )) {
             Button {
-              viewStore.send(.push)
+              viewStore.send(.start)
             } label: {
-              Text("Push 1")
+              Text("Start")
             }
             .buttonStyle(.borderedProminent)
             .controlSize(.large)
@@ -156,7 +156,6 @@ struct NavigationStackExampleView: View {
 
   // MARK: - Child Views
 
-  @available(iOS 16, *)
   struct DestinationView: View {
     let store: StoreOf<NavigationStackExample.Destination>
 

--- a/Example/Example/NavigationStackExample.swift
+++ b/Example/Example/NavigationStackExample.swift
@@ -1,0 +1,135 @@
+import ComposableArchitecture
+import ComposablePresentation
+import SwiftUI
+
+struct NavigationStackExample: ReducerProtocol {
+  struct State {
+    var detail: Detail.State?
+  }
+
+  enum Action {
+    case push(Detail.State)
+    case pop
+    case detail(Detail.Action)
+  }
+
+  var body: some ReducerProtocol<State, Action> {
+    Reduce { state, action in
+      switch action {
+      case .push(let detail):
+        state.detail = detail
+        return .none
+
+      case .pop, .detail(.didTapDismiss):
+        state.detail = nil
+        return .none
+
+      case .detail(_):
+        return .none
+      }
+    }
+    .presenting(
+      state: .keyPath(\.detail),
+      id: .keyPath(\.?.id),
+      action: /Action.detail,
+      presented: Detail.init
+    )
+  }
+
+  // MARK: - Child Reducers
+
+  struct Detail: ReducerProtocol {
+    struct State: Identifiable {
+      var id: String
+      var timer = TimerExample.State()
+    }
+
+    enum Action {
+      case didTapDismiss
+      case timer(TimerExample.Action)
+    }
+
+    var body: some ReducerProtocol<State, Action> {
+      Scope(state: \.timer, action: /Action.timer) {
+        TimerExample()
+      }
+    }
+  }
+}
+
+struct NavigationStackExampleView: View {
+  let store: StoreOf<NavigationStackExample>
+
+  var body: some View {
+    if #available(iOS 16, *) {
+      WithViewStore(store.stateless) { viewStore in
+        NavigationStack {
+          VStack {
+            Button(action: { viewStore.send(.push(.init(id: "A"))) }) {
+              Text("Push A")
+            }
+
+            Button(action: { viewStore.send(.push(.init(id: "B"))) }) {
+              Text("Push B")
+            }
+
+            Button(action: { viewStore.send(.push(.init(id: "C"))) }) {
+              Text("Push C")
+            }
+          }
+          .navigationTitle("Root")
+          .navigationDestination(
+            store.scope(
+              state: \.detail,
+              action: NavigationStackExample.Action.detail
+            ),
+            mapState: replayNonNil(),
+            onDismiss: { viewStore.send(.pop) },
+            content: DetailView.init(store:)
+          )
+        }
+      }
+    } else {
+      Text("iOS ≥ 16 required")
+    }
+  }
+
+  // MARK: - Child Views
+
+  struct DetailView: View {
+    let store: StoreOf<NavigationStackExample.Detail>
+
+    struct ViewState: Equatable {
+      init(state: NavigationStackExample.Detail.State) {
+        id = state.id
+      }
+
+      var id: String
+    }
+
+    var body: some View {
+      WithViewStore(store, observe: ViewState.init) { viewStore in
+        VStack {
+          TimerExampleView(store: store.scope(
+            state: \.timer,
+            action: NavigationStackExample.Detail.Action.timer
+          ))
+
+          Button(action: { viewStore.send(.didTapDismiss) }) {
+            Text("Dismiss").padding()
+          }
+        }
+        .navigationTitle(viewStore.id)
+      }
+    }
+  }
+}
+
+struct NavigationStackExample_Previews: PreviewProvider {
+  static var previews: some View {
+    NavigationStackExampleView(store: Store(
+      initialState: NavigationStackExample.State(),
+      reducer: NavigationStackExample()
+    ))
+  }
+}

--- a/Example/Example/TimerExample.swift
+++ b/Example/Example/TimerExample.swift
@@ -12,17 +12,17 @@ struct TimerExample: ReducerProtocol {
   }
 
   enum Action {
-    case didAppear
-    case didTick
+    case start
+    case tick
   }
 
   func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
-    case .didAppear:
+    case .start:
       return Effect.timer(id: state.id, every: .seconds(1), on: DispatchQueue.main)
-        .map { _ in .didTick }
+        .map { _ in .tick }
 
-    case .didTick:
+    case .tick:
       state.count += 1
       return .none
     }
@@ -35,7 +35,7 @@ struct TimerExampleView: View {
   var body: some View {
     WithViewStore(store, observe: \.count) { viewStore in
       Text("\(viewStore.state)")
-        .onAppear { viewStore.send(.didAppear) }
+        .onAppear { viewStore.send(.start) }
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ SwiftUI example of a component that presents a mutually-exclusive destination. T
 
 Navigation composed with this library is driven by a declarative state. This makes it easy to handle deep links and navigate to any screen of the app. Several workarounds were applied to fix SwiftUI navigation issues (this was only possible thanks to [swiftui-navigation](https://github.com/pointfreeco/swiftui-navigation) library by [Point-Free](https://www.pointfree.co/)). Change the initial state in [Example/App.swift](Example/Example/App.swift) to navigate to any screen when the app starts.
 
+### ▶️ [NavigationStack example](Example/Example/NavigationStackExample.swift)
+
+SwiftUI example of driving `NavigationStack` with a `Store`. The state provides an identifiable array of destination states, which indices make a navigation path. Navigation happens when the array is mutated. This example requires iOS ≥ 16.
+
 ## 🛠 Develop
 
 - Use Xcode (version ≥ 14).


### PR DESCRIPTION
## Summary

This PR adds an example of driving `NavigationStack` with a `Store` that provides a navigation path. iOS ≥ 16 required.

## What was done

- [x] Add `NavigationStoreExample`.
