### PR TITLE
NavigationStack helpers

### DIFF
--- a/Example/Example/NavigationStackExample.swift
+++ b/Example/Example/NavigationStackExample.swift
@@ -116,15 +116,11 @@ struct NavigationStackExampleView: View {
             .buttonStyle(.borderedProminent)
             .controlSize(.large)
             .navigationTitle("Root")
-            .navigationDestination(for: NavigationStackExample.State.Path.Element.self) { id in
-              IfLetStore(
-                store.scope(
-                  state: { $0.stack[id: id] },
-                  action: { NavigationStackExample.Action.destination(id, $0) }
-                ),
-                then: DestinationView.init(store:)
-              )
-            }
+            .navigationDestination(
+              forEach: store.scope(state: \.stack),
+              action: NavigationStackExample.Action.destination,
+              destination: DestinationView.init(store:)
+            )
           }
 
           Divider()

--- a/Example/Example/NavigationStackExample.swift
+++ b/Example/Example/NavigationStackExample.swift
@@ -105,8 +105,9 @@ struct NavigationStackExampleView: View {
     if #available(iOS 16, *) {
       WithViewStore(store, observe: \.path) { viewStore in
         VStack(spacing: 0) {
-          NavigationStack(path: viewStore.binding(
-            send: NavigationStackExample.Action.updatePath
+          NavigationStackWithStore(store.scope(
+            state: { Array($0.stack.ids) },
+            action: NavigationStackExample.Action.updatePath
           )) {
             Button {
               viewStore.send(.start)

--- a/Example/Example/NavigationStackExample.swift
+++ b/Example/Example/NavigationStackExample.swift
@@ -4,16 +4,14 @@ import SwiftUI
 
 struct NavigationStackExample: ReducerProtocol {
   struct State {
-    typealias Path = [Destination.State.ID]
     var stack: IdentifiedArrayOf<Destination.State> = []
-    var path: Path { Array(stack.ids) }
   }
 
   enum Action {
-    case updatePath(State.Path)
+    case updatePath([Destination.State.ID])
     case start
     case popToRoot
-    case popTo(State.Path.Element)
+    case popTo(Destination.State.ID)
     case destination(_ id: Destination.State.ID, _ action: Destination.Action)
   }
 
@@ -82,8 +80,8 @@ struct NavigationStackExample: ReducerProtocol {
     }
 
     enum Action {
-      case push(NavigationStackExample.State.Path)
-      case set(NavigationStackExample.State.Path)
+      case push([Destination.State.ID])
+      case set([Destination.State.ID])
       case pop
       case popToRoot
       case shuffle
@@ -103,12 +101,12 @@ struct NavigationStackExampleView: View {
 
   var body: some View {
     if #available(iOS 16, *) {
-      WithViewStore(store, observe: \.path) { viewStore in
-        VStack(spacing: 0) {
-          NavigationStackWithStore(store.scope(
-            state: { Array($0.stack.ids) },
-            action: NavigationStackExample.Action.updatePath
-          )) {
+      VStack(spacing: 0) {
+        NavigationStackWithStore(store.scope(
+          state: { Array($0.stack.ids) },
+          action: NavigationStackExample.Action.updatePath
+        )) {
+          WithViewStore(store.stateless) { viewStore in
             Button {
               viewStore.send(.start)
             } label: {
@@ -117,15 +115,17 @@ struct NavigationStackExampleView: View {
             .buttonStyle(.borderedProminent)
             .controlSize(.large)
             .navigationTitle("Root")
-            .navigationDestination(
-              forEach: store.scope(state: \.stack),
-              action: NavigationStackExample.Action.destination,
-              destination: DestinationView.init(store:)
-            )
           }
+          .navigationDestination(
+            forEach: store.scope(state: \.stack),
+            action: NavigationStackExample.Action.destination,
+            destination: DestinationView.init(store:)
+          )
+        }
 
-          Divider()
+        Divider()
 
+        WithViewStore(store, observe: \.stack.ids) { viewStore in
           ScrollView(.horizontal, showsIndicators: false) {
             HStack {
               Button {
@@ -143,8 +143,8 @@ struct NavigationStackExampleView: View {
                 }
               }
             }
-            .padding()
           }
+          .padding()
         }
       }
     } else {

--- a/Sources/ComposablePresentation/NavigationDestinationForEachStore.swift
+++ b/Sources/ComposablePresentation/NavigationDestinationForEachStore.swift
@@ -1,0 +1,30 @@
+import ComposableArchitecture
+import SwiftUI
+
+extension View {
+  /// Associates a destination view with a presented data type for use within a navigation stack.
+  ///
+  /// - Parameters:
+  ///   - store: Store with state of `IdentifiedArray<ID, State>` and `ParentAction`.
+  ///   - action: Embeds `Action` for `ID` in a `ParentAction`.
+  ///   - mapState: Maps the state. Defaults to a closure that returns unchanged state.
+  ///   - destination: Creates destination view with a store of `State` and `Action`.
+  /// - Returns: View with navigation destination applied.
+  @available(iOS 16, macOS 13, *)
+  public func navigationDestination<ID: Hashable, State, Action, ParentAction, Destination: View>(
+    forEach store: Store<IdentifiedArray<ID, State>, ParentAction>,
+    action: @escaping (ID, Action) -> ParentAction,
+    mapState: @escaping (State?) -> State? = { $0 },
+    destination: @escaping (Store<State, Action>) -> Destination
+  ) -> some View {
+    navigationDestination(for: ID.self) { id in
+      IfLetStore(
+        store.scope(
+          state: { mapState($0[id: id]) },
+          action: { action(id, $0) }
+        ),
+        then: destination
+      )
+    }
+  }
+}

--- a/Sources/ComposablePresentation/NavigationStackWithStore.swift
+++ b/Sources/ComposablePresentation/NavigationStackWithStore.swift
@@ -1,0 +1,34 @@
+import ComposableArchitecture
+import SwiftUI
+
+/// `NavigationStack` driven by `Store`
+@available(iOS 16, macOS 13, *)
+public struct NavigationStackWithStore<ID: Hashable, Root: View>: View {
+  /// Create `NavigationStack` wrapped with `WithViewStore`.
+  ///
+  /// - State of the store provides navigation path of type `[ID]`.
+  /// - Whenever navigation path changes, an action with updated path is sent to the store.
+  ///
+  /// - Parameters:
+  ///   - store: Store with state and action of `[ID]`.
+  ///   - root: Creates root view.
+  public init(
+    _ store: Store<[ID], [ID]>,
+    root: @escaping () -> Root
+  ) {
+    self.store = store
+    self.root = root
+  }
+
+  let store: Store<[ID], [ID]>
+  let root: () -> Root
+
+  public var body: some View {
+    WithViewStore(store) { viewStore in
+      NavigationStack(
+        path: viewStore.binding(send: { $0 }),
+        root: root
+      )
+    }
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds SwiftUI helpers for `NavigationStack`. See the updated example for more details.

## What was done

- [x] Add `NavigationDestinationForEachStore` - SwiftUI view modifier.
- [x] Add `NavigationStackWithStore` - SwiftUI view.
- [x] Update `NavigationStackExample`.
