### PR TITLE
Swift concurrency

### DIFF
--- a/ComposablePresentation.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ComposablePresentation.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-case-paths",
       "state" : {
-        "revision" : "f623901b4bcc97f59c36704f81583f169b228e51",
-        "version" : "0.13.0"
+        "revision" : "870133b7b2387df136ad301ec67b2e864b51dda1",
+        "version" : "0.14.0"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-composable-architecture.git",
       "state" : {
-        "revision" : "cd22f6a1b3a6210e1e365cbfa8706dbb1736ca27",
-        "version" : "0.51.0"
+        "revision" : "3e8eee1efe99d06e99426d421733b858b332186b",
+        "version" : "0.52.0"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "dd86159e25c749873f144577e5d18309bf57534f",
-        "version" : "0.8.0"
+        "revision" : "de8ba65649e7ee317b9daf27dd5eebf34bd4be57",
+        "version" : "0.9.1"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies",
       "state" : {
-        "revision" : "8282b0c59662eb38946afe30eb403663fc2ecf76",
-        "version" : "0.1.4"
+        "revision" : "6bb1034e8a1bfbf46dfb766b6c09b7b17e1cba10",
+        "version" : "0.2.0"
       }
     },
     {
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swiftui-navigation",
       "state" : {
-        "revision" : "270a754308f5440be52fc295242eb7031638bd15",
-        "version" : "0.6.1"
+        "revision" : "0a0e1b321d70ee6a464ecfe6b0136d9eff77ebfc",
+        "version" : "0.7.0"
       }
     },
     {
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "62041e6016a30f56952f5d7d3f12a3fd7029e1cd",
-        "version" : "0.8.3"
+        "revision" : "ab8c9f45843694dd16be4297e6d44c0634fd9913",
+        "version" : "0.8.4"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -41,3 +41,17 @@ let package = Package(
     ),
   ]
 )
+
+//for target in package.targets {
+//  target.swiftSettings = target.swiftSettings ?? []
+//  target.swiftSettings?.append(
+//    .unsafeFlags([
+//      "-Xfrontend", "-warn-concurrency",
+//      "-Xfrontend", "-strict-concurrency=complete",
+//      "-Xfrontend", "-enable-actor-data-race-checks",
+//      "-enable-library-evolution",
+//      "-Xfrontend", "-debug-time-function-bodies",
+//      "-Xfrontend", "-debug-time-expression-type-checking",
+//    ])
+//  )
+//}

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
   dependencies: [
     .package(
       url: "https://github.com/pointfreeco/swift-composable-architecture.git",
-      .upToNextMajor(from: "0.51.0")
+      .upToNextMajor(from: "0.52.0")
     ),
   ],
   targets: [

--- a/Sources/ComposablePresentation/FullScreenCoverWithStore.swift
+++ b/Sources/ComposablePresentation/FullScreenCoverWithStore.swift
@@ -1,8 +1,6 @@
 import ComposableArchitecture
 import SwiftUI
 
-#if os(iOS)
-
 extension View {
   /// Adds full screen cover using `Store` with an optional `State`
   ///
@@ -14,6 +12,8 @@ extension View {
   ///   - onDismiss: Invoked when full screen cover is dismissed.
   ///   - content: Creates content view with a store with unwrapped state.
   /// - Returns: View with full screen cover added in a background view.
+  @available(iOS 14, tvOS 14, watchOS 7, *)
+  @available(macOS, unavailable)
   @MainActor
   public func fullScreenCover<State, Action, Content: View>(
     _ store: Store<State?, Action>,
@@ -44,5 +44,3 @@ extension View {
     )
   }
 }
-
-#endif

--- a/Sources/ComposablePresentation/FullScreenCoverWithStore.swift
+++ b/Sources/ComposablePresentation/FullScreenCoverWithStore.swift
@@ -14,6 +14,7 @@ extension View {
   ///   - onDismiss: Invoked when full screen cover is dismissed.
   ///   - content: Creates content view with a store with unwrapped state.
   /// - Returns: View with full screen cover added in a background view.
+  @MainActor
   public func fullScreenCover<State, Action, Content: View>(
     _ store: Store<State?, Action>,
     mapState: @escaping (State?) -> State? = { $0 },

--- a/Sources/ComposablePresentation/NavigationDestinationWithStore.swift
+++ b/Sources/ComposablePresentation/NavigationDestinationWithStore.swift
@@ -13,6 +13,7 @@ extension View {
   ///   - content: Creates content view with a store with unwrapped state.
   /// - Returns: View with navigation destination applied.
   @available(iOS 16, macOS 13, *)
+  @MainActor
   public func navigationDestination<State, Action, Content: View>(
     _ store: Store<State?, Action>,
     mapState: @escaping (State?) -> State? = { $0 },

--- a/Sources/ComposablePresentation/PopoverWithStore.swift
+++ b/Sources/ComposablePresentation/PopoverWithStore.swift
@@ -16,6 +16,7 @@ extension View {
   ///       The default is `.top`.
   ///   - content: Creates content view with a store with unwrapped state.
   /// - Returns: View with popover added in a background view.
+  @MainActor
   public func popover<State, Action, Content: View>(
     _ store: Store<State?, Action>,
     mapState: @escaping (State?) -> State? = { $0 },

--- a/Sources/ComposablePresentation/SheetWithStore.swift
+++ b/Sources/ComposablePresentation/SheetWithStore.swift
@@ -12,6 +12,7 @@ extension View {
   ///   - onDismiss: Invoked when sheet is dismissed.
   ///   - content: Creates content view with a store with unwrapped state.
   /// - Returns: View with sheet added in a background view.
+  @MainActor
   public func sheet<State, Action, Content: View>(
     _ store: Store<State?, Action>,
     mapState: @escaping (State?) -> State? = { $0 },

--- a/Tests/ComposablePresentationTests/PresentingCaseReducerTests.swift
+++ b/Tests/ComposablePresentationTests/PresentingCaseReducerTests.swift
@@ -50,16 +50,16 @@ final class PresentingCaseReducerTests: XCTestCase {
       struct State: Equatable {}
       struct Action {}
 
-      var didFireEffect: () -> Void
-      var didCancelEffect: () -> Void
+      var didFireEffect: @Sendable @MainActor () -> Void
+      var didCancelEffect: @Sendable @MainActor () -> Void
 
       func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
-        .run { _ in
-          didFireEffect()
+        .run { [didFireEffect, didCancelEffect] _ in
+          await didFireEffect()
           while !Task.isCancelled {
             await Task.yield()
           }
-          didCancelEffect()
+          await didCancelEffect()
         }
       }
     }
@@ -68,16 +68,16 @@ final class PresentingCaseReducerTests: XCTestCase {
       struct State: Equatable {}
       struct Action {}
 
-      var didFireEffect: () -> Void
-      var didCancelEffect: () -> Void
+      var didFireEffect: @Sendable @MainActor () -> Void
+      var didCancelEffect: @Sendable @MainActor () -> Void
 
       func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
-        .run { _ in
-          didFireEffect()
+        .run { [didFireEffect, didCancelEffect] _ in
+          await didFireEffect()
           while !Task.isCancelled {
             await Task.yield()
           }
-          didCancelEffect()
+          await didCancelEffect()
         }
       }
     }


### PR DESCRIPTION
## Summary

This PR addresses swift-concurrency errors & warnings that appears when building with the following flags:

- `-warn-concurrency`
- `-strict-concurrency=complete`
- `-enable-actor-data-race-checks`

## What was done

- [x] Update package dependencies
- [x] Silence swift-concurrency main-actor warnings
- [x] Mark `View.fullScreenCover` with `@available`
